### PR TITLE
nuxt上でsassとmixinsとwebフォントがうまく動かなかったので直した

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -34,7 +34,7 @@ export default {
   css: [],
 
   // Plugins to run before rendering page (https://go.nuxtjs.dev/config-plugins)
-  plugins: [],
+  plugins: ['~/plugins/adobe-fonts'],
 
   // Auto import components (https://go.nuxtjs.dev/config-components)
   components: true,

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -46,13 +46,21 @@ export default {
   ],
 
   // Modules (https://go.nuxtjs.dev/config-modules)
-  modules: [],
+  modules: ['@nuxtjs/style-resources'],
 
   // WebFont
   webfontloader: {
     google: {
       families: ['Noto+Sans+JP:wght@400;700'],
     },
+  },
+
+  styleResources: {
+    scss: [
+      '@/assets/scss/variables.scss',
+      '@/assets/scss/mixins.scss',
+      '@/assets/scss/reset.scss',
+    ],
   },
 
   // Build Configuration (https://go.nuxtjs.dev/config-build)

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@nuxtjs/eslint-config": "^3.1.0",
     "@nuxtjs/eslint-module": "^2.0.0",
     "@nuxtjs/storybook": "^3.3.0",
+    "@nuxtjs/style-resources": "^1.0.0",
     "@storybook/addon-actions": "^6.1.11",
     "@storybook/addon-essentials": "^6.1.11",
     "@storybook/addon-knobs": "^6.1.11",

--- a/src/assets/scss/mixins.scss
+++ b/src/assets/scss/mixins.scss
@@ -53,13 +53,13 @@
 }
 
 @mixin font-en-normal {
-  font-family: museo-sans, sans-serif;
+  font-family: museo-sans, Arial, Helvetica, Verdana, sans-serif;
   font-weight: 300;
   font-style: normal;
 }
 
 @mixin font-en-bold {
-  font-family: museo-sans, sans-serif;
+  font-family: museo-sans, Arial, Helvetica, Verdana, sans-serif;
   font-weight: 700;
   font-style: normal;
 }

--- a/src/components/Atoms/Logo/index.vue
+++ b/src/components/Atoms/Logo/index.vue
@@ -26,7 +26,7 @@
 
 <style lang="scss" scoped>
 h1 {
-  // @include font-en-normal;
+  @include font-en-bold;
 }
 .NuxtLogo {
   animation: 1s appear;

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -4,6 +4,16 @@
   </div>
 </template>
 
+<script>
+export default {
+  mounted() {
+    this.$nextTick(function () {
+      this.$adobeFonts(document)
+    })
+  },
+}
+</script>
+
 <style>
 html {
   font-family: 'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI',
@@ -15,6 +25,12 @@ html {
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   box-sizing: border-box;
+  /* webfontチラツキ防止 */
+  visibility: hidden;
+}
+html.wf-active {
+  /* webfontチラツキ防止 */
+  visibility: visible;
 }
 
 *,

--- a/src/plugins/adobe-fonts.js
+++ b/src/plugins/adobe-fonts.js
@@ -1,0 +1,34 @@
+/* eslint-disable */
+export default function ({ app }, inject) {
+  const adobeFonts = (d) => {
+    var config = {
+        kitId: 'mxk7gts',
+        scriptTimeout: 3000,
+        async: true,
+      },
+      h = d.documentElement,
+      t = setTimeout(function () {
+        h.className =
+          h.className.replace(/\bwf-loading\b/g, '') + ' wf-inactive'
+      }, config.scriptTimeout),
+      tk = d.createElement('script'),
+      f = false,
+      s = d.getElementsByTagName('script')[0],
+      a
+    h.className += ' wf-loading'
+    tk.src = 'https://use.typekit.net/' + config.kitId + '.js'
+    tk.async = true
+    tk.onload = tk.onreadystatechange = function () {
+      a = this.readyState
+      if (f || (a && a != 'complete' && a != 'loaded')) return
+      f = true
+      clearTimeout(t)
+      try {
+        Typekit.load(config)
+      } catch (e) {}
+    }
+    s.parentNode.insertBefore(tk, s)
+  }
+
+  inject('adobeFonts', adobeFonts)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1634,6 +1634,15 @@
     jiti "^0.1.17"
     upath "^2.0.1"
 
+"@nuxtjs/style-resources@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/style-resources/-/style-resources-1.0.0.tgz#7c4d6be19d7f7cc5d687d689f2ab16c0b94773a1"
+  integrity sha512-tDRcC/pm8B0Kpxtzb/1/HOBkv3/kPD+2FiCiUBGMB7YriRud9OUPw1pnYCsAH9ftwpMJS4k4XOyUY8FCTk6OxA==
+  dependencies:
+    consola "^2.4.0"
+    glob-all "^3.1.0"
+    sass-resources-loader "^2.0.0"
+
 "@nuxtjs/youch@^4.2.3":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@nuxtjs/youch/-/youch-4.2.3.tgz#36f8b22df5a0efaa81373109851e1d857aca6bed"
@@ -4318,6 +4327,15 @@ cliui@^5.0.0:
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
 
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
+
 clone@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
@@ -4487,7 +4505,7 @@ connect@^3.7.0:
     parseurl "~1.3.3"
     utils-merge "1.0.1"
 
-consola@^2.10.0, consola@^2.11.3, consola@^2.15.0, consola@^2.6.0, consola@^2.9.0:
+consola@^2.10.0, consola@^2.11.3, consola@^2.15.0, consola@^2.4.0, consola@^2.6.0, consola@^2.9.0:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/consola/-/consola-2.15.0.tgz#40fc4eefa4d2f8ef2e2806147f056ea207fcc0e9"
   integrity sha512-vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ==
@@ -6622,6 +6640,14 @@ github-slugger@^1.0.0:
   integrity sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==
   dependencies:
     emoji-regex ">=6.0.0 <=6.1.1"
+
+glob-all@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/glob-all/-/glob-all-3.2.1.tgz#082ca81afd2247cbd3ed2149bb2630f4dc877d95"
+  integrity sha512-x877rVkzB3ipid577QOp+eQCR6M5ZyiwrtaYgrX/z3EThaSPFtLDwBXFHc3sH1cG0R0vFYI5SRYeWMMSEyXkUw==
+  dependencies:
+    glob "^7.1.2"
+    yargs "^15.3.1"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -11601,7 +11627,7 @@ sass-resources-loader@^1.3.1:
     glob "^7.1.1"
     loader-utils "^1.0.4"
 
-sass-resources-loader@^2.1.1:
+sass-resources-loader@^2.0.0, sass-resources-loader@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/sass-resources-loader/-/sass-resources-loader-2.1.1.tgz#a231b7c4e326d9c8d141909c901233bef9453151"
   integrity sha512-/KrD5mEBTj3ZQ49thKSThhpv1OFhc82JbWA0bmv9yANRuPIlQrydNpZG82jdy4pEWY0QcQTGyd5OmCb3xVeZsw==
@@ -13649,6 +13675,14 @@ yargs-parser@^13.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^18.1.2:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs@^13.3.2:
   version "13.3.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
@@ -13664,6 +13698,23 @@ yargs@^13.3.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
+
+yargs@^15.3.1:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
+  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.2"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## 概要
storybookでは動いたけど、nuxt上ではmixins諸々がエラーだったので調整
調整の数めっちゃ多い（愚痴）

## 変更内容
 - `@nuxtjs/style-resources`インストール
 - nuxt.config.jsのmodulesに@nuxtjs/style-resourcesを追加
 - nuxt.config.jsのstyleResourcesに反映させたいscssを記載
 - AdobeFontを読み込むためのplugin追加
 - nuxt.config.jsのpluginに上記のパスを追加
 - `layout/default.vue`のscriptにadobefontを呼び出すメソッドを追加
 - 読み込み時にフォントのちらつきがある（らしい）のでcssで調整

## 参考
 - [Nuxt.js環境にScssを導入して使いやすい設定までしてみる](https://papadays.com/post/1zixpiuritiebkicxyibeh/)
 - [NuxtでAdobe Fontsを利用する（日本語対応）](https://mykii.blog/nuxt-use-adobefonts-ja/#AdobeFontsID)
