### PR TITLE
nuxt-linkがstorybook上でエラーになるのでaタグに変換

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,9 +1,28 @@
-import { addDecorator } from '@storybook/vue'
+import { configure, addDecorator } from '@storybook/vue'
 import { withKnobs } from '@storybook/addon-knobs'
+import { action } from '@storybook/addon-actions'
 
 import Vue from 'vue'
 import Vuex from 'vuex'
 
 Vue.use(Vuex)
+
+// nuxt-link を action に送る
+Vue.component('nuxt-link', {
+  props: ['to'],
+  methods: {
+    log() {
+      action('link target')(this.to)
+    },
+  },
+  template: '<a href="#" @click.prevent="log()"><slot>NuxtLink</slot></a>',
+})
+
+const req = require.context('../src/components', true, /.stories.js$/)
+function loadStories() {
+  req.keys().forEach(filename => req(filename))
+}
+
+configure(loadStories, module)
 
 addDecorator(withKnobs)

--- a/src/components/Atoms/TextLink/index.stories.js
+++ b/src/components/Atoms/TextLink/index.stories.js
@@ -3,13 +3,15 @@ import TextLink from './index.vue'
 export default {
   title: 'Atoms/TextLink',
   components: TextLink,
-  argTypes: {
-    onClick: { action: 'clicked' },
-  },
 }
 
-export const $default = (argTypes) => ({
+const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { TextLink },
-  template: '<text-link @onClick="onClick">テキストリンク</text-link>',
+  template: '<text-link v-bind="$props">テキストリンク</text-link>',
 })
+
+export const Default = Template.bind({})
+Default.args = {
+  to: 'https://nuxtjs.org',
+}

--- a/src/components/Atoms/TextLink/index.vue
+++ b/src/components/Atoms/TextLink/index.vue
@@ -1,12 +1,13 @@
 <template>
-  <nuxt-link to="/" class="text-link" @click="onClick"><slot></slot></nuxt-link>
+  <nuxt-link :to="to" class="text-link"><slot></slot></nuxt-link>
 </template>
 
 <script>
 export default {
-  methods: {
-    onClick() {
-      this.$emit('onClick')
+  props: {
+    to: {
+      type: String,
+      required: true,
     },
   },
 }
@@ -17,6 +18,7 @@ export default {
   font-size: 1.4rem;
   line-height: 1.6;
   color: $link-color;
+  text-decoration: none;
   position: relative;
   &::before {
     display: block;

--- a/src/components/Modules/Navigation/index.vue
+++ b/src/components/Modules/Navigation/index.vue
@@ -2,7 +2,7 @@
   <nav class="navigation">
     <ul class="navigation-list">
       <li class="navigation-list__item">
-        <nuxt-link class="navigation-list__link" to="/">About</nuxt-link>
+        <nuxt-link class="navigation-list__link" to="/about">About</nuxt-link>
       </li>
     </ul>
   </nav>
@@ -27,6 +27,7 @@
   &__link {
     padding: 10px 0;
     color: $text-color;
+    text-decoration: none;
     cursor: pointer;
     position: relative;
     &::before {

--- a/src/components/Modules/WorkCard/index.stories.js
+++ b/src/components/Modules/WorkCard/index.stories.js
@@ -16,6 +16,7 @@ const Template = (args, { argTypes }) => ({
 
 export const Default = Template.bind({})
 Default.args = {
+  to: '/',
   src: 'images/work-image.png',
   alt: '作品イメージです',
   title: '#001 Profile',

--- a/src/components/Modules/WorkCard/index.vue
+++ b/src/components/Modules/WorkCard/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <nuxt-link class="work-card" @click="onClick">
+  <nuxt-link :to="to" class="work-card">
     <figure class="work-card__thumb">
       <img :src="src" :alt="alt" />
     </figure>
@@ -13,6 +13,10 @@
 <script>
 export default {
   props: {
+    to: {
+      type: String,
+      required: true,
+    },
     src: {
       type: String,
       required: true,
@@ -26,11 +30,6 @@ export default {
       required: true,
     },
   },
-  methods: {
-    onClick() {
-      this.$emit('onClick')
-    },
-  },
 }
 </script>
 
@@ -39,6 +38,7 @@ export default {
   width: 100%;
   display: block;
   box-shadow: 2px 2px 2px rgba(176, 233, 233, 1);
+  text-decoration: none;
   cursor: pointer;
   transition: all 0.3s ease;
   &:hover {


### PR DESCRIPTION
## 概要
nuxt-linkがstorybook上でエラーになるのでaタグに変換

## 変更内容
 - preview.jsにactionを追加
 - preview.jsにnuxt-linkをaタグに変換するコンポーネント追加
 - nuxt-linkにあるonClick削除
 - props: `to`を追加
 - nuxt-linkをaタグと判定されたのでデフォルトスタイルの下線を削除

## 参考サイト
- [`nuxt-link` タグのリンクをStorybook上で確認する方法](https://qiita.com/sawami2019/items/407b85fc78e6c04fac5c)
- [Nuxt + Vuetify の構成で Storybook を導入する](https://almond.milk200.cc/blog/2020/06/01/storybook.html)