### PR TITLE
aboutページ実装

### DIFF
--- a/src/components/Atoms/BaseButton/index.stories.js
+++ b/src/components/Atoms/BaseButton/index.stories.js
@@ -1,7 +1,7 @@
 import BaseButton from './index.vue'
 
 export default {
-  title: 'Atoms/Button',
+  title: 'Atoms/BaseButton',
   components: BaseButton,
   argTypes: {
     size: {

--- a/src/components/Atoms/BaseButton/index.vue
+++ b/src/components/Atoms/BaseButton/index.vue
@@ -13,8 +13,8 @@ export default {
   computed: {
     classes() {
       return {
-        button: true,
-        [`button--${this.size}`]: true,
+        [`base-button`]: true,
+        [`base-button--${this.size}`]: true,
       }
     },
   },
@@ -27,12 +27,12 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.button {
-  display: flex;
+.base-button {
   background: $primary-color;
   color: $white-color;
   text-align: center;
   font-weight: bold;
+  @include font-bold;
   border: 2px solid $primary-color;
   border-radius: 4px;
   overflow: hidden;

--- a/src/components/Atoms/TextLink/index.stories.js
+++ b/src/components/Atoms/TextLink/index.stories.js
@@ -3,15 +3,13 @@ import TextLink from './index.vue'
 export default {
   title: 'Atoms/TextLink',
   components: TextLink,
+  argTypes: {
+    onClick: { action: 'clicked' },
+  },
 }
 
-const Template = (args, { argTypes }) => ({
+export const $default = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { TextLink },
-  template: '<text-link v-bind="$props">テキストリンク</text-link>',
+  template: '<text-link @onClick="onClick">テキストリンク</text-link>',
 })
-
-export const Default = Template.bind({})
-Default.args = {
-  to: 'https://nuxtjs.org',
-}

--- a/src/components/Atoms/TextLink/index.vue
+++ b/src/components/Atoms/TextLink/index.vue
@@ -1,13 +1,12 @@
 <template>
-  <nuxt-link :to="to" class="text-link"><slot></slot></nuxt-link>
+  <button class="text-link" @click="onClick"><slot></slot></button>
 </template>
 
 <script>
 export default {
-  props: {
-    to: {
-      type: String,
-      required: true,
+  methods: {
+    onClick() {
+      this.$emit('onClick')
     },
   },
 }
@@ -15,10 +14,13 @@ export default {
 
 <style lang="scss" scoped>
 .text-link {
+  padding: 0;
   font-size: 1.4rem;
   line-height: 1.6;
   color: $link-color;
   text-decoration: none;
+  border: none;
+  background: transparent;
   position: relative;
   &::before {
     display: block;

--- a/src/components/Atoms/UserIcon/index.stories.js
+++ b/src/components/Atoms/UserIcon/index.stories.js
@@ -5,8 +5,13 @@ export default {
   components: UserIcon,
 }
 
-export const $default = (argTypes) => ({
+export const Template = (argTypes) => ({
   props: Object.keys(argTypes),
   components: { UserIcon },
-  template: '<user-icon />',
+  template: '<user-icon v-bind="$props" />',
 })
+
+export const Default = Template.bind({})
+Default.args = {
+  src: 'images/user-icon.png',
+}

--- a/src/components/Atoms/UserIcon/index.vue
+++ b/src/components/Atoms/UserIcon/index.vue
@@ -1,12 +1,19 @@
 <template>
   <div class="user-icon">
-    <img
-      src="images/user-icon.png"
-      alt="管理者アイコン"
-      class="user-icon__image"
-    />
+    <img :src="src" alt="管理者アイコン" class="user-icon__image" />
   </div>
 </template>
+
+<script>
+export default {
+  props: {
+    src: {
+      type: String,
+      required: true,
+    },
+  },
+}
+</script>
 
 <style lang="scss" scoped>
 .user-icon {

--- a/src/components/Organisms/Header/index.vue
+++ b/src/components/Organisms/Header/index.vue
@@ -1,6 +1,6 @@
 <template>
   <header class="header">
-    <logo @onClick="onClick" />
+    <h1><logo @onClick="onClick" /></h1>
     <navigation />
   </header>
 </template>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <Header />
+    <Header @onClick="toTop" />
     <Nuxt />
     <Footer />
   </div>
@@ -83,6 +83,11 @@ export default {
         c[i]++
       }
     }, 50)
+  },
+  methods: {
+    toTop() {
+      return this.$router.push(`/`)
+    },
   },
 }
 </script>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -105,4 +105,10 @@ html.wf-active {
   box-sizing: border-box;
   margin: 0;
 }
+
+body {
+  font-size: 1.4rem;
+  @include font-normal;
+  color: $text-color;
+}
 </style>

--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="container">
+    <div class="l-wrap">
+      <div class="l-content flex-column">
+        <user-icon :src="require('@/assets/images/user-icon.png')" />
+        <section class="section">
+          <h2 class="user-name">ソーダー</h2>
+          <p class="text">
+            都内で働くWebデザイナー。現在リモートワーク中。このサイトはDaily
+            UIで制作したものをアップしていきます。
+          </p>
+          <p class="text">
+            使用するデザインツール<br />
+            Figma / Illastrator / Photoshop / Xd /
+          </p>
+          <p class="text">
+            広島県出身。<br />
+            ネコととカリカリ梅とカレーが好き。たまに読書と映画の感想を書いたりしてます。
+          </p>
+          <div class="text">
+            <text-link @onClick="toTwitter">Twitter</text-link>
+            <dl>
+              <dt>読書：<text-link @onClick="toBook">ブクログ</text-link></dt>
+              <dt>映画：<text-link @onClick="toMovie">Filmarks</text-link></dt>
+            </dl>
+          </div>
+        </section>
+        <base-button size="medium" @onClick="toTop">ホームに戻る</base-button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import UserIcon from '../components/Atoms/UserIcon'
+import BaseButton from '../components/Atoms/BaseButton'
+import TextLink from '../components/Atoms/TextLink'
+
+export default {
+  components: {
+    UserIcon,
+    BaseButton,
+    TextLink,
+  },
+  methods: {
+    toTwitter() {
+      const url = 'https://twitter.com/T0SH1KO'
+      window.location.href = url
+    },
+    toBook() {
+      const url = 'https://booklog.jp/users/cossmos'
+      window.location.href = url
+    },
+    toMovie() {
+      const url = 'https://filmarks.com/users/so00da'
+      window.location.href = url
+    },
+    toTop() {
+      return this.$router.push(`/`)
+    },
+  },
+}
+</script>
+
+<style lang="scss">
+.l-wrap {
+  width: 100%;
+  margin-top: 80px;
+  background: $white-color;
+  @include media(md, max) {
+    margin-top: 40px;
+  }
+}
+.l-content {
+  width: 100%;
+  max-width: 848px;
+  margin: auto;
+  padding: 80px 24px;
+  position: relative;
+}
+.flex-column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.user-icon {
+  margin-top: -160px;
+  @include media(md, max) {
+    margin-top: -120px;
+  }
+}
+.user-name {
+  margin: 20px 0;
+  font-size: 1.8rem;
+  @include font-bold;
+  @include media(md, max) {
+    text-align: center;
+  }
+}
+.text {
+  margin: 20px 0;
+  line-height: 2;
+}
+.base-button {
+  max-width: 240px;
+  width: 100%;
+  margin: auto;
+}
+</style>


### PR DESCRIPTION
## 概要
aboutページ実装とそれに伴うコンポーネントの調整

## 変更内容
 - ヘッダーロゴをh1に指定
 - UserIconの画像をpropsで指定できるようにした
 - TextLinkをnuxt-linkからbuttonに変更（外部サイトへのリンクに使えないため）
 - Buttonコンポーネントの名称をBaseButtonに統一
 - ページ全体にフォントスタイルを反映
 - ヘッダーロゴに遷移先指定
 - aboutページマークアップ・スタイリング
 - aboutページに載せてるリンクをmethodsで遷移させた

## 参考
- [[Vue]便利なnuxt-linkや$routerだが、外部サイトへのページ遷移はaタグを使うしかない件](https://qiita.com/pon_maeda/items/f4b072d172b65971e761)