### PR TITLE
詳細ページのテキストエリアにmarkdown機能を追加

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -49,7 +49,12 @@ export default {
   ],
 
   // Modules (https://go.nuxtjs.dev/config-modules)
-  modules: ['@nuxtjs/style-resources', 'nuxt-webfontloader', '@nuxtjs/dotenv'],
+  modules: [
+    '@nuxtjs/style-resources',
+    'nuxt-webfontloader',
+    '@nuxtjs/dotenv',
+    '@nuxtjs/markdownit',
+  ],
 
   // WebFont
   webfontloader: {
@@ -89,5 +94,11 @@ export default {
         ]
       })
     },
+  },
+  markdownit: {
+    injected: true, // 「$md」でどこからでも使えるようにする
+    breaks: true, // 改行を<br/>に変換する
+    html: true, // HTML タグを有効にする
+    linkify: true, // URLに似たテキストをリンクに自動変換する
   },
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@nuxtjs/dotenv": "^1.4.1",
+    "@nuxtjs/markdownit": "^1.2.10",
     "contentful": "^8.1.4",
     "core-js": "^3.6.5",
     "nuxt": "^2.14.6"

--- a/src/pages/dailyui/_slug.vue
+++ b/src/pages/dailyui/_slug.vue
@@ -11,9 +11,7 @@
             <span class="works-name__category">DailyUI</span>
             <span class="works-name__title">{{ post.fields.title }}</span>
           </h2>
-          <p class="text">
-            {{ post.fields.body }}
-          </p>
+          <div class="text-area" v-html="$md.render(post.fields.body)"></div>
         </section>
         <Pager>
           <page-previous
@@ -127,7 +125,7 @@ export default {
     font-size: 2rem;
   }
 }
-.text {
+.text-area {
   margin: 20px 0;
   line-height: 2;
 }

--- a/src/pages/dailyui/_slug.vue
+++ b/src/pages/dailyui/_slug.vue
@@ -128,6 +128,61 @@ export default {
 .text-area {
   margin: 20px 0;
   line-height: 2;
+  h1 {
+    font-size: 1.8rem;
+    padding-left: 16px;
+    margin-top: 40px;
+    border-left: 2px solid $text-color;
+  }
+  h2 {
+    font-size: 1.6rem;
+    display: flex;
+    &::before {
+      display: block;
+      content: '●';
+      margin-right: 8px;
+    }
+  }
+  p {
+    margin: 20px 0;
+  }
+  a {
+    padding: 0;
+    font-size: 1.6rem;
+    line-height: 1.6;
+    color: $link-color;
+    text-decoration: none;
+    border: none;
+    background: transparent;
+    position: relative;
+    &::before {
+      display: block;
+      content: '';
+      width: 100%;
+      height: 1px;
+      background: $link-color;
+      transform: scaleX(0);
+      transform-origin: bottom left;
+      position: absolute;
+      bottom: -4px;
+      left: 0;
+      transition: all 0.3s ease;
+    }
+    &:hover {
+      &::before {
+        transform: scaleX(1);
+      }
+    }
+  }
+  ul {
+    margin: 20px 0;
+    padding-left: 24px;
+  }
+  blockquote {
+    padding: 10px 30px;
+    background: lighten($text-color, 75%);
+    border-radius: 4px;
+  }
 }
 .pager {
   margin: 40px 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1627,6 +1627,23 @@
     consola "^2.11.3"
     eslint-loader "^4.0.2"
 
+"@nuxtjs/markdownit-loader@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/markdownit-loader/-/markdownit-loader-1.1.1.tgz#7223b49064a176394f6f82aad3bf622069004799"
+  integrity sha512-ijbEL5QOTRGuykwpikxaanxv5QntRiGYPtBDFvvdhoVNpsfbvROk1QnxCd2tMaYo6zKtpjFQS1RXcluwn5oTXg==
+  dependencies:
+    highlight.js "^9.12.0"
+    loader-utils "^1.1.0"
+    markdown-it "^8.3.1"
+
+"@nuxtjs/markdownit@^1.2.10":
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/markdownit/-/markdownit-1.2.10.tgz#be559cdf45f5569e8c9874b2dcf9fbabc2b11b03"
+  integrity sha512-MWvrVrQNxpnfN4bUUH6mCe7wjpDLj1MUij84u4Rfd4vw+koaj1OzX63Q7MAdrDtFT6Li6yn3YNpq7oJQKmyyPQ==
+  dependencies:
+    "@nuxtjs/markdownit-loader" "^1.1.1"
+    raw-loader "^4.0.1"
+
 "@nuxtjs/storybook@^3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@nuxtjs/storybook/-/storybook-3.3.0.tgz#70c30d9217a5c29ae723a85ae5985f65dd604f74"
@@ -5510,7 +5527,7 @@ enquirer@^2.3.5:
   dependencies:
     ansi-colors "^4.1.1"
 
-entities@^1.1.1, entities@^1.1.2:
+entities@^1.1.1, entities@^1.1.2, entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
@@ -7089,6 +7106,11 @@ highlight.js@^10.1.1, highlight.js@~10.4.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.1.tgz#d48fbcf4a9971c4361b3f95f302747afe19dbad0"
   integrity sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==
 
+highlight.js@^9.12.0:
+  version "9.18.5"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.5.tgz#d18a359867f378c138d6819edfc2a8acd5f29825"
+  integrity sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -8269,6 +8291,13 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+linkify-it@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
+  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
+  dependencies:
+    uc.micro "^1.0.1"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -8525,6 +8554,17 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
+markdown-it@^8.3.1:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.2.tgz#386f98998dc15a37722aa7722084f4020bdd9b54"
+  integrity sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==
+  dependencies:
+    argparse "^1.0.7"
+    entities "~1.1.1"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
 markdown-to-jsx@^6.11.4:
   version "6.11.4"
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz#b4528b1ab668aef7fe61c1535c27e837819392c5"
@@ -8597,7 +8637,7 @@ mdn-data@2.0.4:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
-mdurl@^1.0.0:
+mdurl@^1.0.0, mdurl@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
@@ -12905,6 +12945,11 @@ ua-parser-js@^0.7.22:
   version "0.7.23"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.23.tgz#704d67f951e13195fbcd3d78818577f5bc1d547b"
   integrity sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 uglify-js@^3.5.1:
   version "3.12.2"


### PR DESCRIPTION
## 概要
dailyuiの詳細ページのテキストエリアにmarkdown機能を追加

## 変更内容
 - `@nuxtjs/markdownit`をインストール
 - nuxt.config.jsのmoduleに追記、markdownに設定追加
 - 詳細ページの該当箇所にマークダウンが使えるよう調整
 - マークダウン用のスタイルを追加

## 参考サイト
 - [【Nuxt.js】ContentfulのMarkdown形式のブログコンテンツを表示する](https://developers-book.com/2020/07/14/113/)
 - [vue-markdown をやめて nuxtjs/markdownit を利用する](https://blog.nakamu.life/posts/vue-markdown-nuxtjs-markdownit)
