### PR TITLE
middlewareを活用し記事取得のパフォーマンスを改善する

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -101,4 +101,7 @@ export default {
     html: true, // HTML タグを有効にする
     linkify: true, // URLに似たテキストをリンクに自動変換する
   },
+  router: {
+    middleware: ['getContentful'],
+  },
 }

--- a/src/middleware/getContentful.js
+++ b/src/middleware/getContentful.js
@@ -1,0 +1,3 @@
+export default async ({ store }) => {
+  if (!store.state.posts.length) await store.dispatch('getPosts')
+}

--- a/src/pages/dailyui/_slug.vue
+++ b/src/pages/dailyui/_slug.vue
@@ -3,15 +3,20 @@
     <div class="l-wrap">
       <div class="l-content flex-column">
         <work-image
-          :src="post.fields.headerImage.fields.file.url"
-          :alt="post.fields.title"
+          :src="currentPost.fields.headerImage.fields.file.url"
+          :alt="currentPost.fields.title"
         />
         <section class="l-section l-works">
           <h2 class="works-name">
             <span class="works-name__category">DailyUI</span>
-            <span class="works-name__title">{{ post.fields.title }}</span>
+            <span class="works-name__title">{{
+              currentPost.fields.title
+            }}</span>
           </h2>
-          <div class="text-area" v-html="$md.render(post.fields.body)"></div>
+          <div
+            class="text-area"
+            v-html="$md.render(currentPost.fields.body)"
+          ></div>
         </section>
         <Pager>
           <page-previous
@@ -39,7 +44,6 @@
 import WorkImage from '~/components/Atoms/WorkImage'
 import BaseButton from '~/components/Atoms/BaseButton'
 import Pager from '~/components/Organisms/Pager'
-import client from '~/plugins/contentful.js'
 
 export default {
   components: {
@@ -47,19 +51,15 @@ export default {
     BaseButton,
     Pager,
   },
-  async asyncData({ env, params }) {
-    return await client
-      .getEntries({
-        content_type: env.CTF_BLOG_POST_TYPE_ID,
-        'fields.slug': params.slug,
-        order: '-sys.createdAt',
-      })
-      .then((entries) => {
-        return {
-          post: entries.items[0],
-        }
-      })
-      .catch(console.error)
+  async asyncData({ payload, store, params, error }) {
+    const currentPost =
+      payload ||
+      (await store.state.posts.find((post) => post.fields.slug === params.slug))
+    if (currentPost) {
+      return { currentPost }
+    } else {
+      return error({ statusCode: 400 })
+    }
   },
   methods: {
     onClickPrev() {

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -17,10 +17,10 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import Catch from '~/components/Modules/Catch'
 import WorkCard from '~/components/Modules/WorkCard'
 import CardList from '~/components/Organisms/CardList'
-import client from '~/plugins/contentful.js'
 
 export default {
   components: {
@@ -28,59 +28,8 @@ export default {
     WorkCard,
     CardList,
   },
-  async asyncData({ env }) {
-    return await client
-      .getEntries({
-        content_type: env.CTF_BLOG_POST_TYPE_ID,
-        order: '-sys.createdAt',
-      })
-      .then((res) => {
-        return {
-          posts: res.items,
-        }
-      })
-      .catch(console.error)
-  },
-  data() {
-    return {
-      items: [
-        {
-          id: '01',
-          to: '/',
-          src: require('@/assets/images/work-image.png'),
-          alt: '作品イメージです',
-          title: '#001 Profile',
-        },
-        {
-          id: '02',
-          to: '/',
-          src: require('@/assets/images/work-image.png'),
-          alt: '作品イメージです',
-          title: '#002 Credit Card Checkout',
-        },
-        {
-          id: '03',
-          to: '/',
-          src: require('@/assets/images/work-image.png'),
-          alt: '作品イメージです',
-          title: '#003 LandingPage',
-        },
-        {
-          id: '04',
-          to: '/',
-          src: require('@/assets/images/work-image.png'),
-          alt: '作品イメージです',
-          title: '#004 Calculator',
-        },
-        {
-          id: '05',
-          to: '/',
-          src: require('@/assets/images/work-image.png'),
-          alt: '作品イメージです',
-          title: '#005 App Icon',
-        },
-      ],
-    }
+  computed: {
+    ...mapGetters(['posts']),
   },
 }
 </script>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,31 @@
+import client from '~/plugins/contentful'
+
+export const state = () => ({
+  posts: [],
+})
+
+export const getters = {
+  posts(state) {
+    return state.posts
+  },
+}
+
+export const mutations = {
+  setPosts(state, payload) {
+    state.posts = payload
+  },
+}
+
+export const actions = {
+  async getPosts({ commit }) {
+    await client
+      .getEntries({
+        content_type: process.env.CTF_BLOG_POST_TYPE_ID,
+        order: '-sys.createdAt',
+      })
+      .then((res) => {
+        commit('setPosts', res.items)
+      })
+      .catch(console.error)
+  },
+}


### PR DESCRIPTION
## 概要
参考記事にあったので、実装してみた。

## 変更内容
 - トップでデータ取得してたのをstore側で取得して登録
 - middleware作成。nuxt.config.jsに追加。
 - storeからデータを呼び出してトップに表示
 - payloadを使ってdailyUI各ページにデータ詳細を表示

## 参考サイト
[middlewareを活用しブログ記事取得のパフォーマンスを改善する](https://blog.cloud-acct.com/posts/blog-nuxtjs-middleware)
