### PR TITLE
ページャー機能を追加

### DIFF
--- a/src/components/Modules/PageNext/index.stories.js
+++ b/src/components/Modules/PageNext/index.stories.js
@@ -3,15 +3,12 @@ import PageNext from './index.vue'
 export default {
   title: 'Modules/PageNext',
   component: PageNext,
-  argTypes: {
-    onClick: { action: 'clicked' },
-  },
 }
 
 const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { PageNext },
-  template: '<page-next v-bind="$props" @onClick="onClick" />',
+  template: '<page-next v-bind="$props" />',
 })
 
 export const Default = Template.bind({})
@@ -19,4 +16,5 @@ Default.args = {
   src: 'images/work-image.png',
   alt: '作品イメージです',
   title: '#003 LandingPage',
+  to: '/',
 }

--- a/src/components/Modules/PageNext/index.vue
+++ b/src/components/Modules/PageNext/index.vue
@@ -1,8 +1,8 @@
 <template>
-  <button class="page-next" @click="onClick">
+  <nuxt-link :to="to" class="page-next">
     <div class="page-next__icon"><icon-arrow-right /></div>
     <pager-content :src="src" :alt="alt" progress="Next" :title="title" />
-  </button>
+  </nuxt-link>
 </template>
 
 <script>
@@ -27,10 +27,9 @@ export default {
       type: String,
       required: true,
     },
-  },
-  methods: {
-    onClick() {
-      this.$emit('onClick')
+    to: {
+      type: String,
+      required: true,
     },
   },
 }
@@ -45,6 +44,8 @@ export default {
   padding: 10px 0;
   background: none;
   border: none;
+  text-decoration: none;
+  color: $text-color;
   cursor: pointer;
   position: relative;
   transition: all 0.7s ease;

--- a/src/components/Modules/PagePrevious/index.stories.js
+++ b/src/components/Modules/PagePrevious/index.stories.js
@@ -3,15 +3,12 @@ import PagePrevious from './index.vue'
 export default {
   title: 'Modules/PagePrevious',
   component: PagePrevious,
-  argTypes: {
-    onClick: { action: 'clicked' },
-  },
 }
 
 const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { PagePrevious },
-  template: '<page-previous v-bind="$props" @onClick="onClick" />',
+  template: '<page-previous v-bind="$props" />',
 })
 
 export const Default = Template.bind({})
@@ -19,4 +16,5 @@ Default.args = {
   src: 'images/work-image.png',
   alt: '作品イメージです',
   title: '#002 Credit Card Checkout',
+  to: '/',
 }

--- a/src/components/Modules/PagePrevious/index.vue
+++ b/src/components/Modules/PagePrevious/index.vue
@@ -1,8 +1,8 @@
 <template>
-  <button class="page-previous" @click="onClick">
+  <nuxt-link :to="to" class="page-previous">
     <div class="page-previous__icon"><icon-arrow-left /></div>
     <pager-content :src="src" :alt="alt" progress="Previous" :title="title" />
-  </button>
+  </nuxt-link>
 </template>
 
 <script>
@@ -27,10 +27,9 @@ export default {
       type: String,
       required: true,
     },
-  },
-  methods: {
-    onClick() {
-      this.$emit('onClick')
+    to: {
+      type: String,
+      required: true,
     },
   },
 }
@@ -44,6 +43,8 @@ export default {
   padding: 10px 0;
   background: none;
   border: none;
+  text-decoration: none;
+  color: $text-color;
   cursor: pointer;
   position: relative;
   transition: all 0.7s ease;

--- a/src/components/Organisms/Pager/index.stories.js
+++ b/src/components/Organisms/Pager/index.stories.js
@@ -5,10 +5,6 @@ import PageNext from '~/components/Modules/PageNext'
 export default {
   title: 'Organisms/Pager',
   component: Pager,
-  argTypes: {
-    onClickPrev: { action: 'prev clicked' },
-    onClickNext: { action: 'next clicked' },
-  },
 }
 
 export const $default = (argTypes) => ({
@@ -16,8 +12,8 @@ export const $default = (argTypes) => ({
   components: { Pager, PagePrevious, PageNext },
   template: `
   <Pager>
-    <page-previous src='images/work-image.png' alt='作品イメージです' title='#002 Credit Card Checkout' @onClick="onClickPrev" />
-    <page-next v-bind="$props" src='images/work-image.png' alt='作品イメージです' title='#003 LandingPage' @onClick="onClickNext" />
+    <page-previous src='images/work-image.png' alt='作品イメージです' title='#002 Credit Card Checkout' to="/prev" />
+    <page-next v-bind="$props" src='images/work-image.png' alt='作品イメージです' title='#003 LandingPage' to="/next" />
   </Pager>
   `,
 })

--- a/src/components/Organisms/Pager/index.vue
+++ b/src/components/Organisms/Pager/index.vue
@@ -18,5 +18,8 @@
       width: calc((100% - 20px) / 2);
     }
   }
+  .page-next {
+    margin-left: auto;
+  }
 }
 </style>

--- a/src/pages/dailyui/_slug.vue
+++ b/src/pages/dailyui/_slug.vue
@@ -20,15 +20,17 @@
         </section>
         <Pager>
           <page-previous
-            :src="require('@/assets/images/work-image.png')"
-            alt="作品イメージです"
-            title="#002 Credit Card Checkout"
+            v-if="prevPost"
+            :src="prevPost.fields.headerImage.fields.file.url"
+            :alt="prevPost.fields.title"
+            :title="prevPost.fields.title"
             @onClick="onClickPrev"
           />
           <page-next
-            :src="require('@/assets/images/work-image.png')"
-            alt="作品イメージです"
-            title="#003 LandingPage"
+            v-if="nextPost"
+            :src="nextPost.fields.headerImage.fields.file.url"
+            :alt="nextPost.fields.title"
+            :title="nextPost.fields.title"
             @onClick="onClickNext"
           />
         </Pager>
@@ -55,18 +57,31 @@ export default {
     const currentPost =
       payload ||
       (await store.state.posts.find((post) => post.fields.slug === params.slug))
-    if (currentPost) {
-      return { currentPost }
-    } else {
-      return error({ statusCode: 400 })
+    const indexPost =
+      payload ||
+      (await store.state.posts.findIndex(
+        (post) => post.fields.slug === currentPost.fields.slug
+      ))
+    const length = payload || (await store.state.posts.length)
+    const prev = indexPost - 1
+    const next = indexPost + 1
+    const prevPost = store.state.posts[prev]
+    const nextPost = store.state.posts[next]
+    if ((currentPost, prevPost, nextPost)) {
+      return { currentPost, prevPost, nextPost }
     }
+    if ((currentPost, next === length)) {
+      // 一番古い記事も400になるので救済
+      return { currentPost, prevPost, nextPost }
+    }
+    return error({ statusCode: 400 })
   },
   methods: {
     onClickPrev() {
-      return console.info('前のページに移動')
+      return this.$router.push(`/dailyui/${this.prevPost.fields.slug}`)
     },
     onClickNext() {
-      return console.info('次のページに移動')
+      return this.$router.push(`/dailyui/${this.nextPost.fields.slug}`)
     },
     toTop() {
       return this.$router.push(`/`)

--- a/src/pages/dailyui/_slug.vue
+++ b/src/pages/dailyui/_slug.vue
@@ -57,14 +57,14 @@ export default {
     const currentPost =
       payload ||
       (await store.state.posts.find((post) => post.fields.slug === params.slug))
-    const indexPost =
+    const index =
       payload ||
       (await store.state.posts.findIndex(
         (post) => post.fields.slug === currentPost.fields.slug
       ))
     const length = payload || (await store.state.posts.length)
-    const prev = indexPost - 1
-    const next = indexPost + 1
+    const prev = index - 1
+    const next = index + 1
     const prevPost = store.state.posts[prev]
     const nextPost = store.state.posts[next]
     if ((currentPost, prevPost, nextPost)) {

--- a/src/pages/dailyui/_slug.vue
+++ b/src/pages/dailyui/_slug.vue
@@ -24,14 +24,14 @@
             :src="prevPost.fields.headerImage.fields.file.url"
             :alt="prevPost.fields.title"
             :title="prevPost.fields.title"
-            @onClick="onClickPrev"
+            :to="prevPost.fields.slug"
           />
           <page-next
             v-if="nextPost"
             :src="nextPost.fields.headerImage.fields.file.url"
             :alt="nextPost.fields.title"
             :title="nextPost.fields.title"
-            @onClick="onClickNext"
+            :to="nextPost.fields.slug"
           />
         </Pager>
         <div class="l-home-button">
@@ -77,12 +77,6 @@ export default {
     return error({ statusCode: 400 })
   },
   methods: {
-    onClickPrev() {
-      return this.$router.push(`/dailyui/${this.prevPost.fields.slug}`)
-    },
-    onClickNext() {
-      return this.$router.push(`/dailyui/${this.nextPost.fields.slug}`)
-    },
     toTop() {
       return this.$router.push(`/`)
     },


### PR DESCRIPTION
## 概要
ページャが各ページの前と次のページのテキストやイメージが反映されるよう調整

## 変更内容
 - 現在表示してる記事のindexを取得（index）
 - 全記事の数を取得（length）
 - indexの前を数値を取得（prev）
 - indexの後の数値を取得（next）
 - 前後の記事を取得（prevPost、nextPost）
 - 前と後の記事の有無をv-ifで分岐して表示、非表示
 - ページャに使われてたbuttonを管理のしやすさからnuxt-linkに変更
 - 次へボタンのみのレイアウトを調整

## 参考サイト
 - [連想配列の値からインデックスを取得する](https://qiita.com/Test_test/items/7d532f445f2980e896d0)
 - [JavaScriptでの連想配列の使い方！多次元配列と連想配列の違い](https://www.fenet.jp/dotnet/column/language/4519/#Index)
