### PR TITLE
プレビューの表示がおかしかったので修正

### DIFF
--- a/src/components/Atoms/UserIcon/index.stories.js
+++ b/src/components/Atoms/UserIcon/index.stories.js
@@ -5,7 +5,7 @@ export default {
   components: UserIcon,
 }
 
-export const Template = (argTypes) => ({
+const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { UserIcon },
   template: '<user-icon v-bind="$props" />',


### PR DESCRIPTION
## 概要
ユーザーアイコンコンポーネントのプレビューがおかしかったので修正

## 変更内容
 - `export const Template = (argTypes) => ({` から `const Template = (args, { argTypes }) => `に変更
