### PR TITLE
readme更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,17 @@ $ yarn generate
 ```
 
 For detailed explanation on how things work, check out [Nuxt.js docs](https://nuxtjs.org).
+
+## 運用方法
+
+このリポジトリは[本家](https://github.com/nittashiori/portfolio2020)から fork して作成したリポジトリです。
+
+編集する場合は本家で行います。
+
+```
+本家で編集完了してmasterマージをしたら、このリポジトリに新しく作業ブランチ（本家で作業したブランチと同名）を作成してください。
+
+作業ブランチに`git rebase master`コマンドを叩き、origin に push してマージしてください。（試してないので挙動がよく分からない。挙動確認できたら readme 更新します。）
+
+上記でうまくいかなかったら`remotes/upstream/master`に pull し、直接 master ブランチに push してください。
+```


### PR DESCRIPTION
## 概要
fork元は会社のアカウントで作成したリポジトリのため、会社のNetlifyじゃないと使えないっぽい。
プライベート用のNetlifyは課金しないとfork元のリポジトリを使えないようなので、
プライベート用のリポジトリに複製してNetlifyが使えるようにする。

## 変更内容
 - 本家からリポジトリをfork
 - 本家の内容を追従したいのでこのリポジトリに`upstream`を追加（`git remote add upstream git@github.com:nittashiori/portfolio2020.git`）
 - readmeに運用方法を追加

## 参考サイト
 - [マンガでわかるGit 12話「本家リポジトリに追従する方法」](https://next.rikunabi.com/journal/20180322_t12_iq/)
 - [GitHubのリポジトリを他のアカウントに移動](http://mtoyoshi.hateblo.jp/entry/2013/06/25/171812)
