### PR TITLE
テキストが横幅いっぱいになったら3点リーダーが表示されるようにする

### DIFF
--- a/src/components/Modules/WorkCard/index.vue
+++ b/src/components/Modules/WorkCard/index.vue
@@ -65,6 +65,9 @@ export default {
     font-size: 1.6rem;
     color: $text-color;
     @include font-en-bold;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }
 </style>


### PR DESCRIPTION
## 概要
テキストが横幅いっぱいになったら3点リーダーが表示されるようにする

## 変更内容
 - cssにプロパティ追加（IEとEdgeは知らない）
