### PR TITLE
スマホ版Catchのスタイル調整

### DIFF
--- a/src/components/Modules/Catch/index.vue
+++ b/src/components/Modules/Catch/index.vue
@@ -31,7 +31,7 @@ export default {
   width: 100%;
   padding: 80px 40px 160px;
   @include media(md, max) {
-    padding: 120px 24px;
+    padding: 120px 24px 152px;
   }
   &__title {
     width: 100%;

--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -27,12 +27,10 @@
               </dl>
             </div>
           </section>
-          <div class="l-home-button">
-            <base-button size="medium" @onClick="toTop"
-              >ホームに戻る</base-button
-            >
-          </div>
         </section>
+        <div class="l-home-button">
+          <base-button size="medium" @onClick="toTop">トップに戻る</base-button>
+        </div>
       </div>
     </div>
   </div>
@@ -126,7 +124,7 @@ export default {
 }
 .l-home-button {
   width: 100%;
-  margin-top: 40px;
+  margin-top: 20px;
   display: flex;
   justify-content: center;
 }

--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -28,7 +28,7 @@
             </div>
           </section>
         </section>
-        <div class="l-home-button">
+        <div class="l-top-button">
           <base-button size="medium" @onClick="toTop">トップに戻る</base-button>
         </div>
       </div>
@@ -122,7 +122,7 @@ export default {
 .profile-list {
   margin: 12px 0;
 }
-.l-home-button {
+.l-top-button {
   width: 100%;
   margin-top: 20px;
   display: flex;

--- a/src/pages/dailyui/_slug.vue
+++ b/src/pages/dailyui/_slug.vue
@@ -36,7 +36,7 @@
             :to="prevPost.fields.slug"
           />
         </Pager>
-        <div class="l-home-button">
+        <div class="l-top-button">
           <base-button size="medium" @onClick="toTop">トップに戻る</base-button>
         </div>
       </div>
@@ -253,7 +253,7 @@ export default {
 .pager {
   margin: 40px 0;
 }
-.l-home-button {
+.l-top-button {
   width: 100%;
   margin-top: 20px;
   display: flex;

--- a/src/pages/dailyui/_slug.vue
+++ b/src/pages/dailyui/_slug.vue
@@ -37,7 +37,7 @@
           />
         </Pager>
         <div class="l-home-button">
-          <base-button size="medium" @onClick="toTop">ホームに戻る</base-button>
+          <base-button size="medium" @onClick="toTop">トップに戻る</base-button>
         </div>
       </div>
     </div>
@@ -255,7 +255,7 @@ export default {
 }
 .l-home-button {
   width: 100%;
-  margin-top: 40px;
+  margin-top: 20px;
   display: flex;
   justify-content: center;
 }


### PR DESCRIPTION
## 概要
スマホで見たときにCatchの上の余白が広いので下も同じ余白を取るよう調整。
ついでにホームに戻るボタンの文言とスタイルも調整。

## 変更内容
 - Catchコンポーネントpadding調整
 - ホームに戻る -> トップに戻るに変更
 - `.l-home-button` -> `.l-top-button`に変更
 - `.l-top-button`のmargin-top調整
