### PR TITLE
GAタグ追加

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -93,6 +93,7 @@ export default {
   buildModules: [
     // https://go.nuxtjs.dev/eslint
     '@nuxtjs/eslint-module',
+    '@nuxtjs/google-analytics',
   ],
 
   // Modules (https://go.nuxtjs.dev/config-modules)
@@ -150,5 +151,8 @@ export default {
   },
   router: {
     middleware: ['getContentful'],
+  },
+  googleAnalytics: {
+    id: process.env.GTM_ID,
   },
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -153,6 +153,6 @@ export default {
     middleware: ['getContentful'],
   },
   googleAnalytics: {
-    id: process.env.GTM_ID,
+    id: process.env.GA_ID,
   },
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@nuxtjs/eslint-config": "^3.1.0",
     "@nuxtjs/eslint-module": "^2.0.0",
+    "@nuxtjs/google-analytics": "^2.4.0",
     "@nuxtjs/storybook": "^3.3.0",
     "@nuxtjs/style-resources": "^1.0.0",
     "@storybook/addon-actions": "^6.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1627,6 +1627,13 @@
     consola "^2.11.3"
     eslint-loader "^4.0.2"
 
+"@nuxtjs/google-analytics@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/google-analytics/-/google-analytics-2.4.0.tgz#3bb9f398a05cc23340d1f423f8d8653dc4114f46"
+  integrity sha512-rDQTwHIjyjVrx8GywHPuWykJ3jRFGaHl5Iqji/y8tQWUc0yGEeHxOoR0yimzxnTS1Ph2/PubQYpgnVeEPEdL/A==
+  dependencies:
+    vue-analytics "^5.22.1"
+
 "@nuxtjs/markdownit-loader@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@nuxtjs/markdownit-loader/-/markdownit-loader-1.1.1.tgz#7223b49064a176394f6f82aad3bf622069004799"
@@ -13327,6 +13334,11 @@ void-elements@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
   integrity sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=
+
+vue-analytics@^5.22.1:
+  version "5.22.1"
+  resolved "https://registry.yarnpkg.com/vue-analytics/-/vue-analytics-5.22.1.tgz#9d6b32da56daee1b9dfb23a267b50349a03f710f"
+  integrity sha512-HPKQMN7gfcUqS5SxoO0VxqLRRSPkG1H1FqglsHccz6BatBatNtm/Vyy8brApktZxNCfnAkrSVDpxg3/FNDeOgQ==
 
 vue-client-only@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## 概要
GAタグ追加

## 変更内容
 - `@nuxtjs/google-analytics`インストール
 - envファイルにID追加

## 参考サイト
 - [Googleアナリティクスのトラッキングコードが見当たらない！](https://blog.it-see.net/it-dokata/analytics/unable-to-get-tracking-id/)
 - [google-analytics.nuxtjs](https://google-analytics.nuxtjs.org/)
 - [Nuxtで作ったブログにオススメの便利な設定たち（備忘録）](https://izm51.com/posts/nuxt-blog-first-settings/#google%E3%82%A2%E3%83%8A%E3%83%AA%E3%83%86%E3%82%A3%E3%82%AF%E3%82%B9%E3%81%AE%E8%A8%AD%E7%BD%AE)
