### PR TITLE
絵文字をTwemojiに変更

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -78,6 +78,12 @@ export default {
           'https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap',
       },
     ],
+    script: [
+      {
+        src: 'https://twemoji.maxcdn.com/v/latest/twemoji.min.js',
+        crossorigin: 'anonymous',
+      },
+    ],
   },
 
   // Global CSS (https://go.nuxtjs.dev/config-css)

--- a/src/pages/dailyui/_slug.vue
+++ b/src/pages/dailyui/_slug.vue
@@ -77,6 +77,9 @@ export default {
     }
     return error({ statusCode: 400 })
   },
+  mounted() {
+    window.twemoji.parse(document.body)
+  },
   methods: {
     toTop() {
       return this.$router.push(`/`)
@@ -248,6 +251,12 @@ export default {
       top: 0;
       right: 0;
     }
+  }
+  .emoji {
+    display: inline-block;
+    width: 20px;
+    margin: 0 4px;
+    vertical-align: middle;
   }
 }
 .pager {


### PR DESCRIPTION
## 概要
絵文字をTwemojiにカスタマイズ
（文章に使うのにAppleの絵文字を使うのはいいけど、プレゼンや改変などはNGっぽい。今回と関係はないけど😂）

## 変更内容
 - TwemojiをCDNから読み込み
 - mountedでTwemojiが使えるようにした

## 参考サイト
[Nuxt.jsでリアルタイムでTシャツデザインするアプリ作ったからソース全部公開します](https://qiita.com/nyallpo/items/4939b364d3eddc11823c)
