### PR TITLE
googleフォント、linkからの取得廃止

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -75,11 +75,6 @@ export default {
         rel: 'preconnect',
         href: 'https://fonts.gstatic.com',
       },
-      {
-        rel: 'stylesheet',
-        href:
-          'https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap',
-      },
     ],
   },
 
@@ -110,7 +105,7 @@ export default {
   // WebFont
   webfontloader: {
     google: {
-      families: ['Noto+Sans+JP:wght@400;700'],
+      families: ['Noto+Sans+JP:400,700'],
     },
   },
 


### PR DESCRIPTION
## 概要
googleフォントの取得をリンクから行ってたが、リンクから取得しなくても反映できたので修正

## 変更内容
 - googleフォントへのリンク削除
 - googleフォント指定をちょい調整
