### PR TITLE
@keyframesをtransitionに変更、カードリストにtransition付与

### DIFF
--- a/src/components/Modules/Catch/index.vue
+++ b/src/components/Modules/Catch/index.vue
@@ -3,7 +3,7 @@
     <div class="catch__title">
       <catch-image :typo-src="typoSrc" :circle-src="circleSrc" />
     </div>
-    <transition appear>
+    <transition appear name="fadein">
       <p class="catch__description">WEB DESIGNER’S PORTFOLIO</p>
     </transition>
   </div>
@@ -51,29 +51,17 @@ export default {
     color: $text-color;
     @include font-en-bold;
     letter-spacing: 0.1em;
-    // opacity: 1;
-    // transform: translate(0px, 10px);
-    // animation: fadein 0.4s 0.7s forwards;
     @include media(md, max) {
       font-size: 1.4rem;
     }
   }
-  @keyframes fadein {
-    0% {
-      opacity: 0;
-    }
-    100% {
-      opacity: 100%;
-      transform: translate(0px, 0px);
-    }
-  }
-  .v-enter-active,
-  .v-leave-active {
-    transition: 0.4s 0.7s linear;
+  .fadein-enter-active,
+  .fadein-leave-active {
+    transition: 0.4s 0.7s ease-in-out;
   }
 
-  .v-enter,
-  .v-leave-to {
+  .fadein-enter,
+  .fadein-leave-to {
     opacity: 0;
     transform: translateY(10px);
   }

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -5,17 +5,19 @@
       :circle-src="require('@/assets/images/logo-circle.svg')"
     />
     <div class="l-card">
-      <card-list>
-        <work-card
-          v-for="(post, i) in posts"
-          :key="i"
-          :to="'dailyui/' + post.fields.slug"
-          :src="post.fields.headerImage.fields.file.url"
-          :alt="post.fields.title"
-          :category="post.fields.category"
-          :title="post.fields.title"
-        />
-      </card-list>
+      <transition appear name="fadein">
+        <card-list>
+          <work-card
+            v-for="(post, i) in posts"
+            :key="i"
+            :to="'dailyui/' + post.fields.slug"
+            :src="post.fields.headerImage.fields.file.url"
+            :alt="post.fields.title"
+            :category="post.fields.category"
+            :title="post.fields.title"
+          />
+        </card-list>
+      </transition>
     </div>
   </div>
 </template>
@@ -41,17 +43,15 @@ export default {
 <style lang="scss">
 .l-card {
   padding: 0 24px;
-  // opacity: 0;
-  // transform: translate(0px, 20px);
-  // animation: fadein 0.4s 0.9s forwards;
 }
-@keyframes fadein {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 100%;
-    transform: translate(0px, 0px);
-  }
+.fadein-enter-active,
+.fadein-leave-active {
+  transition: 0.4s 0.9s ease-in-out;
+}
+
+.fadein-enter,
+.fadein-leave-to {
+  opacity: 0;
+  transform: translateY(20px);
 }
 </style>


### PR DESCRIPTION
## 概要
@keyframesを使うとNetlifyで動かないのでtransitionを使って解決した

## 変更内容
 - @keyframes削除
 - アニメーションしたい箇所を`transition`で囲む
 - `v-enter`と`v-leave`でアニメーションを追加

## 参考サイト
 - [初期描画時のトランジション](https://jp.vuejs.org/v2/guide/transitions.html#%E5%88%9D%E6%9C%9F%E6%8F%8F%E7%94%BB%E6%99%82%E3%81%AE%E3%83%88%E3%83%A9%E3%83%B3%E3%82%B8%E3%82%B7%E3%83%A7%E3%83%B3)
 - [Vue.jsのtransitionによるアニメーションの基礎を学ぶ](https://noumenon-th.net/programming/2019/05/25/transition/)