### PR TITLE
aboutページの構成修正

### DIFF
--- a/src/components/Atoms/UserIcon/index.vue
+++ b/src/components/Atoms/UserIcon/index.vue
@@ -20,10 +20,10 @@ export default {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 240px;
-  height: 240px;
+  width: 160px;
+  height: 160px;
   border-radius: 100%;
-  background: $bg-color;
+  background: #fff;
   overflow: hidden;
   @include media(md, max) {
     width: 80px;

--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -2,7 +2,6 @@
   <div class="container">
     <div class="l-wrap">
       <div class="l-content flex-column">
-        <user-icon :src="require('@/assets/images/user-icon.png')" />
         <section class="l-section">
           <h2 class="title">このサイトについて</h2>
           <p class="text">
@@ -13,23 +12,28 @@
             「DailyUI」とは、サイトにメールアドレスを登録して、土日を除く100日間メールでUIデザインのお題を送ってくれるサービスです。<br />
             <text-link @onClick="toDaily">DailyUI公式</text-link>
           </p>
-          <section class="section">
-            <h3 class="sub-title">管理人：ソーダー</h3>
-            <p class="text">
-              広島県出身。都内のweb制作会社に勤めており、現在はリモートワークでお仕事してます。<br />
-              最近はデザインの他にフロントエンドも少しずつ勉強中。<br />
-              趣味の読書と映画鑑賞はたまに感想を書いてます。
-            </p>
-            <div class="text">
-              <text-link @onClick="toTwitter">Twitter</text-link>
-              <dl class="profile-list">
-                <dt>読書：<text-link @onClick="toBook">ブクログ</text-link></dt>
-                <dt>
-                  映画：<text-link @onClick="toMovie">Filmarks</text-link>
-                </dt>
-              </dl>
-            </div>
-          </section>
+          <div class="section profile">
+            <user-icon :src="require('@/assets/images/user-icon.png')" />
+            <section class="profile__info">
+              <h3 class="sub-title">管理人：ソーダー</h3>
+              <p class="text">
+                広島県出身。都内のweb制作会社に勤めており、現在はリモートワークでお仕事してます。<br />
+                最近はデザインの他にフロントエンドも少しずつ勉強中。<br />
+                趣味の読書と映画鑑賞はたまに感想を書いてます。
+              </p>
+              <div class="text">
+                <text-link @onClick="toTwitter">Twitter</text-link>
+                <dl class="profile-list">
+                  <dt>
+                    読書：<text-link @onClick="toBook">ブクログ</text-link>
+                  </dt>
+                  <dt>
+                    映画：<text-link @onClick="toMovie">Filmarks</text-link>
+                  </dt>
+                </dl>
+              </div>
+            </section>
+          </div>
         </section>
         <div class="l-top-button">
           <base-button size="medium" @onClick="toTop">トップに戻る</base-button>
@@ -77,18 +81,18 @@ export default {
 <style lang="scss">
 .l-wrap {
   width: 100%;
-  margin-top: 80px;
+  margin-top: 0;
   background: $white-color;
-  @include media(md, max) {
-    margin-top: 40px;
-  }
 }
 .l-content {
   width: 100%;
   max-width: 848px;
   margin: auto;
-  padding: 80px 24px;
+  padding: 40px 24px 80px;
   position: relative;
+  @include media(md, max) {
+    padding: 24px 24px 80px;
+  }
 }
 .flex-column {
   display: flex;
@@ -102,9 +106,23 @@ export default {
   margin: 40px 0;
 }
 .user-icon {
-  margin-top: -160px;
+  border: 2px solid lighten($text-color, 75%);
+}
+.profile {
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: space-between;
   @include media(md, max) {
-    margin-top: -120px;
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+  }
+  &__info {
+    width: calc(100% - 180px);
+    @include media(md, max) {
+      width: 100%;
+      margin: 10px 0 0;
+    }
   }
 }
 .title {

--- a/src/pages/dailyui/_slug.vue
+++ b/src/pages/dailyui/_slug.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container">
-    <div class="l-wrap">
-      <div class="l-content flex-column">
+    <div class="l-works-wrap">
+      <div class="l-works-content flex-column">
         <work-image
           :src="currentPost.fields.headerImage.fields.file.url"
           :alt="currentPost.fields.title"
@@ -88,7 +88,7 @@ export default {
 </script>
 
 <style lang="scss">
-.l-wrap {
+.l-works-wrap {
   width: 100%;
   margin-top: 80px;
   background: $white-color;
@@ -96,7 +96,7 @@ export default {
     margin-top: 40px;
   }
 }
-.l-content {
+.l-works-content {
   width: 100%;
   max-width: 848px;
   margin: auto;


### PR DESCRIPTION
## 概要
aboutの構成を変更。

## 変更内容
 - ユーザーアイコンをプロフィールエリアに移動
 - プロフィールエリアのレイアウト修正
 - aboutのレイアウトクラス修正に伴い_slugで同じクラスも変更反映するのでクラスを分けた
