### PR TITLE
googlefontからadobefontに以降

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -95,19 +95,7 @@ export default {
   ],
 
   // Modules (https://go.nuxtjs.dev/config-modules)
-  modules: [
-    '@nuxtjs/style-resources',
-    'nuxt-webfontloader',
-    '@nuxtjs/dotenv',
-    '@nuxtjs/markdownit',
-  ],
-
-  // WebFont
-  webfontloader: {
-    google: {
-      families: ['Noto+Sans+JP:400,700'],
-    },
-  },
+  modules: ['@nuxtjs/style-resources', '@nuxtjs/dotenv', '@nuxtjs/markdownit'],
 
   styleResources: {
     scss: [

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "eslint-plugin-prettier": "^3.1.4",
     "node-sass": "^5.0.0",
     "nuxt-sass-resources-loader": "^2.0.5",
-    "nuxt-webfontloader": "^1.1.0",
     "prettier": "^2.1.2",
     "sass-loader": "^10.1.0",
     "sass-resources-loader": "^2.1.1"

--- a/src/assets/scss/mixins.scss
+++ b/src/assets/scss/mixins.scss
@@ -43,23 +43,23 @@
 
 /// webフォント設定
 @mixin font-normal {
-  font-family: "Noto Sans JP", "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", "Osaka", sans-serif;
+  font-family: "source-han-sans-japanese", "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", "Osaka", sans-serif;
   font-weight: 400;
 }
 
 @mixin font-bold {
-  font-family: "Noto Sans JP", "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", "Osaka", sans-serif;
+  font-family: "source-han-sans-japanese", "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", "Osaka", sans-serif;
   font-weight: 700;
 }
 
 @mixin font-en-normal {
-  font-family: museo-sans, Arial, Helvetica, Verdana, "Noto Sans JP", "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", sans-serif;
+  font-family: museo-sans, Arial, Helvetica, Verdana, "source-han-sans-japanese", "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", sans-serif;
   font-weight: 300;
   font-style: normal;
 }
 
 @mixin font-en-bold {
-  font-family: museo-sans, Arial, Helvetica, Verdana, "Noto Sans JP", "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", sans-serif;
+  font-family: museo-sans, Arial, Helvetica, Verdana, "source-han-sans-japanese", "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", sans-serif;
   font-weight: 700;
   font-style: normal;
 }

--- a/src/plugins/adobe-fonts.js
+++ b/src/plugins/adobe-fonts.js
@@ -2,7 +2,7 @@
 export default function ({ app }, inject) {
   const adobeFonts = (d) => {
     var config = {
-        kitId: 'mxk7gts',
+        kitId: 'iyy1yik',
         scriptTimeout: 3000,
         async: true,
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9226,13 +9226,6 @@ nuxt-sass-resources-loader@^2.0.5:
   dependencies:
     sass-resources-loader "^1.3.1"
 
-nuxt-webfontloader@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/nuxt-webfontloader/-/nuxt-webfontloader-1.1.0.tgz#68b47ffbeaee4c41969f42f57a86946e0c36715c"
-  integrity sha512-GyDgABmI0Oq54s2tA9SZC28TmHy2xGdWSXrfcGPPfDBVhgQQlGL5CJcAlvovcuhefzzZrzGgs35HIcv5qym4fQ==
-  dependencies:
-    webfontloader "^1.6.28"
-
 nuxt@^2.14.6:
   version "2.14.12"
   resolved "https://registry.yarnpkg.com/nuxt/-/nuxt-2.14.12.tgz#836096ff62ba72554b73744d94f5547109e563f7"
@@ -13505,11 +13498,6 @@ web-namespaces@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
-
-webfontloader@^1.6.28:
-  version "1.6.28"
-  resolved "https://registry.yarnpkg.com/webfontloader/-/webfontloader-1.6.28.tgz#db786129253cb6e8eae54c2fb05f870af6675bae"
-  integrity sha1-23hhKSU8tujq5UwvsF+HCvZnW64=
 
 webpack-bundle-analyzer@^3.9.0:
   version "3.9.0"


### PR DESCRIPTION
## 概要
googlefontからNotoSansCJKを参照すると読み込み時間がかかるので、
Adobefontの`source-han-sans-japanese`に変更した。

## 変更内容
 - webfontloaderの記述削除
 - nuxt-webfontloaderアンインストール
 - plugin内のIDを変更
 - font-familyにsource-han-sans-japaneseを追加
