### PR TITLE
lazyload追加

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -82,7 +82,11 @@ export default {
   css: [],
 
   // Plugins to run before rendering page (https://go.nuxtjs.dev/config-plugins)
-  plugins: ['~/plugins/adobe-fonts', '~/plugins/contentful'],
+  plugins: [
+    '~/plugins/adobe-fonts',
+    '~/plugins/contentful',
+    { src: '~/plugins/vue-lazyload.js', ssr: false },
+  ],
 
   // Auto import components (https://go.nuxtjs.dev/config-components)
   components: true,

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "nuxt-sass-resources-loader": "^2.0.5",
     "prettier": "^2.1.2",
     "sass-loader": "^10.1.0",
-    "sass-resources-loader": "^2.1.1"
+    "sass-resources-loader": "^2.1.1",
+    "vue-lazyload": "^1.3.3"
   }
 }

--- a/src/components/Atoms/UserIcon/index.vue
+++ b/src/components/Atoms/UserIcon/index.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="user-icon">
-    <img :src="src" alt="管理者アイコン" class="user-icon__image" />
+    <client-only>
+      <lazy-component>
+        <img :src="src" alt="管理者アイコン" class="user-icon__image" />
+      </lazy-component>
+    </client-only>
   </div>
 </template>
 

--- a/src/components/Atoms/WorkImage/index.vue
+++ b/src/components/Atoms/WorkImage/index.vue
@@ -1,5 +1,9 @@
 <template>
-  <img class="work-image" :src="src" :alt="alt" />
+  <client-only>
+    <lazy-component>
+      <img class="work-image" :src="src" :alt="alt" />
+    </lazy-component>
+  </client-only>
 </template>
 
 <script>

--- a/src/components/Modules/PagerContent/index.vue
+++ b/src/components/Modules/PagerContent/index.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="pager-content">
     <figure class="pager-content__thumb">
-      <img :src="src" :alt="alt" />
+      <client-only>
+        <lazy-component>
+          <img :src="src" :alt="alt" />
+        </lazy-component>
+      </client-only>
     </figure>
     <div class="pager-content__inner">
       <p class="pager-content__progress">{{ progress }}</p>

--- a/src/components/Modules/WorkCard/index.vue
+++ b/src/components/Modules/WorkCard/index.vue
@@ -1,7 +1,11 @@
 <template>
   <nuxt-link :to="to" class="work-card">
     <figure class="work-card__thumb">
-      <img :src="src" :alt="alt" />
+      <client-only>
+        <lazy-component>
+          <img :src="src" :alt="alt" />
+        </lazy-component>
+      </client-only>
     </figure>
     <div class="work-card__body">
       <p class="work-card__category">{{ category }}</p>

--- a/src/plugins/vue-lazyload.js
+++ b/src/plugins/vue-lazyload.js
@@ -1,0 +1,6 @@
+import Vue from 'vue'
+import VueLazyload from 'vue-lazyload'
+
+Vue.use(VueLazyload, {
+  lazyComponent: true,
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -13389,6 +13389,11 @@ vue-inbrowser-compiler-utils@^4.33.6:
   dependencies:
     camelcase "^5.3.1"
 
+vue-lazyload@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/vue-lazyload/-/vue-lazyload-1.3.3.tgz#4df50a271bde9b74c3caf7a228d6e0af50d5682f"
+  integrity sha512-uHnq0FTEeNmqnbBC2aRKlmtd9LofMZ6Q3mWvgfLa+i9vhxU8fDK+nGs9c1iVT85axSua/AUnMttIq3xPaU9G3A==
+
 vue-loader@^15.9.5:
   version "15.9.5"
   resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-15.9.5.tgz#7a960dc420a3439deaacdda038fdcdbf7c432706"


### PR DESCRIPTION
## 概要
lazyload追加

## 変更内容
 - vue-lazyloadインストール
 - plugin作成、modulesで読み込み
 - imgタグをlazy-componentで囲む

## 参考サイト
- [vue-lazyloadを導入して本ブログの画像を遅延ロードする](https://blog.nakamu.life/posts/vue-lazyload)