### PR TITLE
404最終調整

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -127,6 +127,7 @@ export default {
   },
   // 動的ルーティング追加
   generate: {
+    fallback: true,
     routes() {
       return Promise.all([
         client.getEntries({

--- a/src/layouts/error.vue
+++ b/src/layouts/error.vue
@@ -36,7 +36,7 @@ export default {
   props: {
     error: {
       type: Object,
-      required: true,
+      default: null,
     },
   },
   layout: 'error', // エラーページ用のカスタムレイアウトを指定できます


### PR DESCRIPTION
## 概要
Netlifyで404が表示されないので調整

## 変更内容
 - nuxt.configのgenerateにfallback追加
 - propsのerrorのrequiredをdefaultに変更

## 参考サイト
https://note.com/koushikagawa/n/ne78d83de1113