### PR TITLE
投稿をカテゴリー別で出力させる

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -136,7 +136,10 @@ export default {
       ]).then(([posts]) => {
         return [
           ...posts.items.map((post) => {
-            return { route: `dailyui/${post.fields.slug}`, payload: post }
+            return {
+              route: `${post.fields.category.fields.slug}/${post.fields.slug}`,
+              payload: post,
+            }
           }),
         ]
       })

--- a/src/components/Modules/Catch/index.vue
+++ b/src/components/Modules/Catch/index.vue
@@ -19,9 +19,9 @@ export default {
 <style lang="scss" scoped>
 .catch {
   width: 100%;
-  padding: 80px 40px 160px;
+  padding: 40px 40px 120px;
   @include media(md, max) {
-    padding: 120px 24px 152px;
+    padding: 64px 24px 96px;
   }
   &__title {
     width: 100%;

--- a/src/components/Modules/Navigation/index.vue
+++ b/src/components/Modules/Navigation/index.vue
@@ -29,11 +29,10 @@
     font-size: 1.6rem;
     @include font-en-bold;
     &:not(:first-child) {
-      margin-left: 20px;
-    }
-    @include media(md, max) {
-      font-size: 1.4rem;
-      margin-left: 4vw;
+      margin-left: 40px;
+      @include media(md, max) {
+        margin-left: 6vw;
+      }
     }
   }
   &__link {

--- a/src/components/Modules/Navigation/index.vue
+++ b/src/components/Modules/Navigation/index.vue
@@ -3,9 +3,13 @@
     <ul class="navigation-list">
       <li class="navigation-list__item">
         <nuxt-link class="navigation-list__link" to="/about">About</nuxt-link>
+      </li>
+      <li class="navigation-list__item">
         <nuxt-link class="navigation-list__link" to="/dailyui"
           >DailyUI</nuxt-link
         >
+      </li>
+      <li class="navigation-list__item">
         <nuxt-link class="navigation-list__link" to="/tips">Tips</nuxt-link>
       </li>
     </ul>
@@ -29,11 +33,11 @@
     }
     @include media(md, max) {
       font-size: 1.4rem;
+      margin-left: 4vw;
     }
   }
   &__link {
     padding: 10px 0;
-    margin: 0 0 0 4vw;
     color: $text-color;
     text-decoration: none;
     cursor: pointer;

--- a/src/components/Modules/Navigation/index.vue
+++ b/src/components/Modules/Navigation/index.vue
@@ -18,6 +18,7 @@
   width: 100%;
 }
 .navigation-list {
+  width: 100%;
   display: flex;
   justify-content: flex-end;
   &__item {
@@ -32,7 +33,7 @@
   }
   &__link {
     padding: 10px 0;
-    margin: 0 0 0 24px;
+    margin: 0 0 0 4vw;
     color: $text-color;
     text-decoration: none;
     cursor: pointer;

--- a/src/components/Modules/Navigation/index.vue
+++ b/src/components/Modules/Navigation/index.vue
@@ -3,6 +3,10 @@
     <ul class="navigation-list">
       <li class="navigation-list__item">
         <nuxt-link class="navigation-list__link" to="/about">About</nuxt-link>
+        <nuxt-link class="navigation-list__link" to="/dailyui"
+          >DailyUI</nuxt-link
+        >
+        <nuxt-link class="navigation-list__link" to="/tips">Tips</nuxt-link>
       </li>
     </ul>
   </nav>
@@ -26,6 +30,7 @@
   }
   &__link {
     padding: 10px 0;
+    margin: 0 0 0 24px;
     color: $text-color;
     text-decoration: none;
     cursor: pointer;

--- a/src/components/Modules/Navigation/index.vue
+++ b/src/components/Modules/Navigation/index.vue
@@ -15,9 +15,11 @@
 <style lang="scss" scoped>
 .navigation {
   padding: 10px 0;
+  width: 100%;
 }
 .navigation-list {
   display: flex;
+  justify-content: flex-end;
   &__item {
     font-size: 1.6rem;
     @include font-en-bold;

--- a/src/components/Modules/PagerContent/index.vue
+++ b/src/components/Modules/PagerContent/index.vue
@@ -45,7 +45,7 @@ export default {
     align-items: flex-start;
   }
   &__thumb {
-    width: 144px;
+    width: 120px;
     @include media(md, max) {
       width: 100%;
     }

--- a/src/middleware/getContentful.js
+++ b/src/middleware/getContentful.js
@@ -1,3 +1,4 @@
 export default async ({ store }) => {
   if (!store.state.posts.length) await store.dispatch('getPosts')
+  if (!store.state.categories.length) await store.dispatch('getCategories')
 }

--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -7,6 +7,7 @@
           <p class="text">
             とあるwebデザイナーのポートフォリオサイトです。<br />
             ここではDailyUIで制作したものを投稿していきます。更新はゆるめです。<br />
+            たまにデザインや技術についても書いていこうと思います。
           </p>
           <p class="text description">
             「DailyUI」とは、サイトにメールアドレスを登録して、土日を除く100日間メールでUIデザインのお題を送ってくれるサービスです。<br />
@@ -19,18 +20,18 @@
               <p class="text">
                 広島県出身。都内のweb制作会社に勤めており、現在はリモートワークでお仕事してます。<br />
                 最近はデザインの他にフロントエンドも少しずつ勉強中。<br />
-                趣味の読書と映画鑑賞はたまに感想を書いてます。
+                炭酸水をこよなく愛する。
               </p>
               <div class="text">
                 <text-link @onClick="toTwitter">Twitter</text-link>
-                <dl class="profile-list">
+                <!-- <dl class="profile-list">
                   <dt>
                     読書：<text-link @onClick="toBook">ブクログ</text-link>
                   </dt>
                   <dt>
                     映画：<text-link @onClick="toMovie">Filmarks</text-link>
                   </dt>
-                </dl>
+                </dl> -->
               </div>
             </section>
           </div>
@@ -86,7 +87,7 @@ export default {
 }
 .l-content {
   width: 100%;
-  max-width: 848px;
+  max-width: 672px;
   margin: auto;
   padding: 40px 24px 80px;
   position: relative;

--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -16,10 +16,9 @@
           <div class="section profile">
             <user-icon :src="require('@/assets/images/user-icon.png')" />
             <section class="profile__info">
-              <h3 class="sub-title">管理人：ソーダー</h3>
+              <h3 class="sub-title">管理人：新田詩織（ソーダー）</h3>
               <p class="text">
-                広島県出身。都内のweb制作会社に勤めており、現在はリモートワークでお仕事してます。<br />
-                最近はデザインの他にフロントエンドも少しずつ勉強中。<br />
+                広島県出身。都内のweb制作会社に勤めているwebデザイナー。現在はリモートワークでお仕事してます。<br />
                 炭酸水をこよなく愛する。
               </p>
               <div class="text">

--- a/src/pages/dailyui/_slug.vue
+++ b/src/pages/dailyui/_slug.vue
@@ -134,7 +134,7 @@ export default {
     display: block;
     margin-top: 4px;
     @include font-en-bold;
-    font-size: 2.6rem;
+    font-size: 2.8rem;
   }
 }
 .text-area {
@@ -166,7 +166,7 @@ export default {
     }
   }
   h3 {
-    margin: 20px 0 10px;
+    margin: 20px 0;
     font-size: 2rem;
     line-height: 1.6;
     display: flex;
@@ -177,7 +177,7 @@ export default {
   }
   p,
   img {
-    margin: 20px 0;
+    margin: 28px 0;
   }
   img {
     width: 100%;

--- a/src/pages/dailyui/_slug.vue
+++ b/src/pages/dailyui/_slug.vue
@@ -47,8 +47,6 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
-
 import WorkImage from '~/components/Atoms/WorkImage'
 import BaseButton from '~/components/Atoms/BaseButton'
 import Pager from '~/components/Organisms/Pager'
@@ -62,8 +60,10 @@ export default {
   async asyncData({ payload, store, params, error }) {
     const currentPost =
       payload ||
-      (await store.state.posts.find((post) => post.fields.slug === params.slug))
-    const category = await store.state.categories.find(
+      (await store.getters.posts.find(
+        (post) => post.fields.slug === params.slug
+      ))
+    const category = await store.getters.categories.find(
       (cat) => cat.fields.slug === currentPost.fields.category.fields.slug
     )
     const relatedPosts = await store.getters.relatedPosts(category)
@@ -80,9 +80,6 @@ export default {
       return { currentPost, category, relatedPosts, index, prevPost, nextPost }
     }
     return error({ statusCode: 400 })
-  },
-  computed: {
-    ...mapGetters(['posts']),
   },
   methods: {
     toTop() {

--- a/src/pages/dailyui/_slug.vue
+++ b/src/pages/dailyui/_slug.vue
@@ -16,9 +16,7 @@
           <!-- eslint-disable vue/no-v-html -->
           <div
             class="text-area"
-            v-html="
-              $md.render(currentPost.fields.body.content[0].content[0].value)
-            "
+            v-html="$md.render(currentPost.fields.body)"
           ></div>
           <!-- eslint-enable -->
         </section>
@@ -100,7 +98,7 @@ export default {
 }
 .l-works-content {
   width: 100%;
-  max-width: 848px;
+  max-width: 672px;
   margin: auto;
   padding: 80px 24px;
   position: relative;
@@ -118,7 +116,7 @@ export default {
 }
 .work-image {
   width: 100%;
-  max-width: 848px;
+  max-width: 672px;
   margin: auto;
   margin-top: -160px;
   @include media(md, max) {
@@ -126,7 +124,6 @@ export default {
   }
 }
 .works-name {
-  margin: 20px 0;
   &__category {
     display: block;
     margin: 10px 0;
@@ -145,13 +142,14 @@ export default {
   line-height: 2;
   h1 {
     padding: 10px 0;
-    font-size: 2.2rem;
+    font-size: 2.4rem;
     line-height: 1.6;
     border-bottom: 2px dotted lighten($text-color, 60%);
     margin: 40px 0 20px;
     @include font-bold;
     @include media(md, max) {
       font-size: 2rem;
+      margin: 32px 0 20px;
     }
   }
   h2 {
@@ -162,16 +160,19 @@ export default {
     border-left: 2px solid $text-color;
     margin: 40px 0 20px;
     @include font-bold;
+    @include media(md, max) {
+      font-size: 1.8rem;
+      margin: 32px 0 20px;
+    }
   }
   h3 {
-    font-size: 1.6rem;
+    margin: 20px 0 10px;
+    font-size: 2rem;
     line-height: 1.6;
     display: flex;
     @include font-bold;
-    &::before {
-      display: block;
-      content: '●';
-      margin-right: 8px;
+    @include media(md, max) {
+      font-size: 1.6rem;
     }
   }
   p,
@@ -228,7 +229,28 @@ export default {
     border: 1px solid lighten($text-color, 60%);
     border-radius: 4px;
   }
-  code,
+  code {
+    margin: 0 4px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    background: lighten($text-color, 72%);
+    color: $text-color;
+  }
+  pre {
+    margin: 10px 0;
+    padding: 16px 24px;
+    background: $text-color;
+    border-radius: 4px;
+    overflow: scroll;
+    @include media(md, max) {
+      padding: 12px 16px;
+    }
+    code {
+      color: $white-color;
+      font-size: 1.4rem;
+      background: transparent;
+    }
+  }
   em {
     @include font-bold;
   }

--- a/src/pages/dailyui/index.vue
+++ b/src/pages/dailyui/index.vue
@@ -9,7 +9,7 @@
           :src="post.fields.headerImage.fields.file.url"
           :alt="post.fields.title"
           :category="post.fields.category.fields.name"
-          :title="post.fields.slug"
+          :title="post.fields.title"
         />
       </card-list>
     </div>

--- a/src/pages/dailyui/index.vue
+++ b/src/pages/dailyui/index.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="container">
+    <div class="l-card">
+      <card-list>
+        <work-card
+          v-for="(post, i) in relatedPosts"
+          :key="i"
+          :to="post.fields.category.fields.slug + '/' + post.fields.slug"
+          :src="post.fields.headerImage.fields.file.url"
+          :alt="post.fields.title"
+          :category="post.fields.category.fields.name"
+          :title="post.fields.slug"
+        />
+      </card-list>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import WorkCard from '~/components/Modules/WorkCard'
+import CardList from '~/components/Organisms/CardList'
+
+export default {
+  components: {
+    WorkCard,
+    CardList,
+  },
+  async asyncData({ payload, store, error }) {
+    const currentPost =
+      payload ||
+      (await store.getters.posts.find(
+        (post) => post.fields.category.fields.slug === 'dailyui'
+      ))
+    const category = await store.getters.categories.find(
+      (cat) => cat.fields.slug === currentPost.fields.category.fields.slug
+    )
+    const relatedPosts = await store.getters.relatedPosts(category)
+    if (currentPost) {
+      return { currentPost, category, relatedPosts }
+    }
+    return error({ statusCode: 400 })
+  },
+  computed: {
+    ...mapGetters(['posts']),
+  },
+}
+</script>
+
+<style lang="scss">
+.l-card {
+  padding: 0 24px;
+}
+</style>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -7,10 +7,10 @@
           <work-card
             v-for="(post, i) in posts"
             :key="i"
-            :to="'dailyui/' + post.fields.slug"
+            :to="post.fields.category.fields.slug + '/' + post.fields.slug"
             :src="post.fields.headerImage.fields.file.url"
             :alt="post.fields.title"
-            :category="post.fields.category"
+            :category="post.fields.category.fields.name"
             :title="post.fields.title"
           />
         </card-list>
@@ -32,7 +32,7 @@ export default {
     CardList,
   },
   computed: {
-    ...mapGetters(['posts']),
+    ...mapGetters(['posts', 'categories']),
   },
 }
 </script>

--- a/src/pages/tips/_slug.vue
+++ b/src/pages/tips/_slug.vue
@@ -134,7 +134,7 @@ export default {
     display: block;
     margin-top: 4px;
     @include font-en-bold;
-    font-size: 2.6rem;
+    font-size: 2.8rem;
   }
 }
 .text-area {
@@ -166,7 +166,7 @@ export default {
     }
   }
   h3 {
-    margin: 20px 0 10px;
+    margin: 20px 0;
     font-size: 2rem;
     line-height: 1.6;
     display: flex;
@@ -177,7 +177,7 @@ export default {
   }
   p,
   img {
-    margin: 20px 0;
+    margin: 28px 0;
   }
   img {
     width: 100%;

--- a/src/pages/tips/_slug.vue
+++ b/src/pages/tips/_slug.vue
@@ -1,51 +1,43 @@
 <template>
-  <div>
-    <div class="container">
-      <div class="l-works-wrap">
-        <div class="l-works-content flex-column">
-          <work-image
-            :src="currentPost.fields.headerImage.fields.file.url"
-            :alt="currentPost.fields.title"
+  <div class="container">
+    <div class="l-works-wrap">
+      <div class="l-works-content flex-column">
+        <work-image
+          :src="currentPost.fields.headerImage.fields.file.url"
+          :alt="currentPost.fields.title"
+        />
+        <section class="l-section l-works">
+          <h2 class="works-name">
+            <span class="works-name__category">{{ category.fields.name }}</span>
+            <span class="works-name__title">{{
+              currentPost.fields.title
+            }}</span>
+          </h2>
+          <!-- eslint-disable vue/no-v-html -->
+          <div
+            class="text-area"
+            v-html="$md.render(currentPost.fields.body)"
+          ></div>
+          <!-- eslint-enable -->
+        </section>
+        <Pager>
+          <page-next
+            v-if="nextPost"
+            :src="nextPost.fields.headerImage.fields.file.url"
+            :alt="nextPost.fields.title"
+            :title="nextPost.fields.title"
+            :to="nextPost.fields.slug"
           />
-          <section class="l-section l-works">
-            <h2 class="works-name">
-              <span class="works-name__category">{{
-                category.fields.name
-              }}</span>
-              <span class="works-name__title">{{
-                currentPost.fields.title
-              }}</span>
-            </h2>
-            <!-- eslint-disable vue/no-v-html -->
-            <div
-              class="text-area"
-              v-html="
-                $md.render(currentPost.fields.body.content[0].content[0].value)
-              "
-            ></div>
-            <!-- eslint-enable -->
-          </section>
-          <Pager>
-            <page-next
-              v-if="nextPost"
-              :src="nextPost.fields.headerImage.fields.file.url"
-              :alt="nextPost.fields.title"
-              :title="nextPost.fields.title"
-              :to="nextPost.fields.slug"
-            />
-            <page-previous
-              v-if="prevPost"
-              :src="prevPost.fields.headerImage.fields.file.url"
-              :alt="prevPost.fields.title"
-              :title="prevPost.fields.title"
-              :to="prevPost.fields.slug"
-            />
-          </Pager>
-          <div class="l-top-button">
-            <base-button size="medium" @onClick="toTop"
-              >トップに戻る</base-button
-            >
-          </div>
+          <page-previous
+            v-if="prevPost"
+            :src="prevPost.fields.headerImage.fields.file.url"
+            :alt="prevPost.fields.title"
+            :title="prevPost.fields.title"
+            :to="prevPost.fields.slug"
+          />
+        </Pager>
+        <div class="l-top-button">
+          <base-button size="medium" @onClick="toTop">トップに戻る</base-button>
         </div>
       </div>
     </div>
@@ -106,7 +98,7 @@ export default {
 }
 .l-works-content {
   width: 100%;
-  max-width: 848px;
+  max-width: 672px;
   margin: auto;
   padding: 80px 24px;
   position: relative;
@@ -124,7 +116,7 @@ export default {
 }
 .work-image {
   width: 100%;
-  max-width: 848px;
+  max-width: 672px;
   margin: auto;
   margin-top: -160px;
   @include media(md, max) {
@@ -132,7 +124,6 @@ export default {
   }
 }
 .works-name {
-  margin: 20px 0;
   &__category {
     display: block;
     margin: 10px 0;
@@ -151,13 +142,14 @@ export default {
   line-height: 2;
   h1 {
     padding: 10px 0;
-    font-size: 2.2rem;
+    font-size: 2.4rem;
     line-height: 1.6;
     border-bottom: 2px dotted lighten($text-color, 60%);
     margin: 40px 0 20px;
     @include font-bold;
     @include media(md, max) {
       font-size: 2rem;
+      margin: 32px 0 20px;
     }
   }
   h2 {
@@ -168,16 +160,19 @@ export default {
     border-left: 2px solid $text-color;
     margin: 40px 0 20px;
     @include font-bold;
+    @include media(md, max) {
+      font-size: 1.8rem;
+      margin: 32px 0 20px;
+    }
   }
   h3 {
-    font-size: 1.6rem;
+    margin: 20px 0 10px;
+    font-size: 2rem;
     line-height: 1.6;
     display: flex;
     @include font-bold;
-    &::before {
-      display: block;
-      content: '●';
-      margin-right: 8px;
+    @include media(md, max) {
+      font-size: 1.6rem;
     }
   }
   p,
@@ -234,7 +229,28 @@ export default {
     border: 1px solid lighten($text-color, 60%);
     border-radius: 4px;
   }
-  code,
+  code {
+    margin: 0 4px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    background: lighten($text-color, 72%);
+    color: $text-color;
+  }
+  pre {
+    margin: 10px 0;
+    padding: 16px 24px;
+    background: $text-color;
+    border-radius: 4px;
+    overflow: scroll;
+    @include media(md, max) {
+      padding: 12px 16px;
+    }
+    code {
+      color: $white-color;
+      font-size: 1.4rem;
+      background: transparent;
+    }
+  }
   em {
     @include font-bold;
   }

--- a/src/pages/tips/_slug.vue
+++ b/src/pages/tips/_slug.vue
@@ -1,0 +1,286 @@
+<template>
+  <div>
+    <div class="container">
+      <div class="l-works-wrap">
+        <div class="l-works-content flex-column">
+          <work-image
+            :src="currentPost.fields.headerImage.fields.file.url"
+            :alt="currentPost.fields.title"
+          />
+          <section class="l-section l-works">
+            <h2 class="works-name">
+              <span class="works-name__category">{{
+                category.fields.name
+              }}</span>
+              <span class="works-name__title">{{
+                currentPost.fields.title
+              }}</span>
+            </h2>
+            <!-- eslint-disable vue/no-v-html -->
+            <div
+              class="text-area"
+              v-html="
+                $md.render(currentPost.fields.body.content[0].content[0].value)
+              "
+            ></div>
+            <!-- eslint-enable -->
+          </section>
+          <Pager>
+            <page-next
+              v-if="nextPost"
+              :src="nextPost.fields.headerImage.fields.file.url"
+              :alt="nextPost.fields.title"
+              :title="nextPost.fields.title"
+              :to="nextPost.fields.slug"
+            />
+            <page-previous
+              v-if="prevPost"
+              :src="prevPost.fields.headerImage.fields.file.url"
+              :alt="prevPost.fields.title"
+              :title="prevPost.fields.title"
+              :to="prevPost.fields.slug"
+            />
+          </Pager>
+          <div class="l-top-button">
+            <base-button size="medium" @onClick="toTop"
+              >トップに戻る</base-button
+            >
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+
+import WorkImage from '~/components/Atoms/WorkImage'
+import BaseButton from '~/components/Atoms/BaseButton'
+import Pager from '~/components/Organisms/Pager'
+
+export default {
+  components: {
+    WorkImage,
+    BaseButton,
+    Pager,
+  },
+  async asyncData({ payload, store, params, error }) {
+    const currentPost =
+      payload ||
+      (await store.state.posts.find((post) => post.fields.slug === params.slug))
+    const category = await store.state.categories.find(
+      (cat) => cat.fields.slug === currentPost.fields.category.fields.slug
+    )
+    const relatedPosts = await store.getters.relatedPosts(category)
+    const index =
+      payload ||
+      relatedPosts.findIndex(
+        (post) => post.fields.slug === currentPost.fields.slug
+      )
+    const prev = index + 1
+    const next = index - 1
+    const prevPost = relatedPosts[prev]
+    const nextPost = relatedPosts[next]
+    if (currentPost) {
+      return { currentPost, category, relatedPosts, prevPost, nextPost }
+    }
+    return error({ statusCode: 400 })
+  },
+  computed: {
+    ...mapGetters(['posts']),
+  },
+  methods: {
+    toTop() {
+      return this.$router.push(`/`)
+    },
+  },
+}
+</script>
+
+<style lang="scss">
+.l-works-wrap {
+  width: 100%;
+  margin-top: 80px;
+  background: $white-color;
+  @include media(md, max) {
+    margin-top: 40px;
+  }
+}
+.l-works-content {
+  width: 100%;
+  max-width: 848px;
+  margin: auto;
+  padding: 80px 24px;
+  position: relative;
+}
+.flex-column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.l-section {
+  width: 100%;
+}
+.l-works {
+  margin-top: 24px;
+}
+.work-image {
+  width: 100%;
+  max-width: 848px;
+  margin: auto;
+  margin-top: -160px;
+  @include media(md, max) {
+    margin-top: -120px;
+  }
+}
+.works-name {
+  margin: 20px 0;
+  &__category {
+    display: block;
+    margin: 10px 0;
+    @include font-en-bold;
+    font-size: 1.6rem;
+  }
+  &__title {
+    display: block;
+    margin-top: 4px;
+    @include font-en-bold;
+    font-size: 2.6rem;
+  }
+}
+.text-area {
+  margin: 20px 0;
+  line-height: 2;
+  h1 {
+    padding: 10px 0;
+    font-size: 2.2rem;
+    line-height: 1.6;
+    border-bottom: 2px dotted lighten($text-color, 60%);
+    margin: 40px 0 20px;
+    @include font-bold;
+    @include media(md, max) {
+      font-size: 2rem;
+    }
+  }
+  h2 {
+    font-size: 2rem;
+    line-height: 1.6;
+    padding-left: 16px;
+    margin-top: 40px;
+    border-left: 2px solid $text-color;
+    margin: 40px 0 20px;
+    @include font-bold;
+  }
+  h3 {
+    font-size: 1.6rem;
+    line-height: 1.6;
+    display: flex;
+    @include font-bold;
+    &::before {
+      display: block;
+      content: '●';
+      margin-right: 8px;
+    }
+  }
+  p,
+  img {
+    margin: 20px 0;
+  }
+  img {
+    width: 100%;
+  }
+  a {
+    padding: 0;
+    font-size: 1.6rem;
+    line-height: 1.6;
+    color: $link-color;
+    text-decoration: none;
+    border: none;
+    background: transparent;
+    position: relative;
+    &::before {
+      display: block;
+      content: '';
+      width: 100%;
+      height: 1px;
+      background: $link-color;
+      transform: scaleX(0);
+      transform-origin: bottom left;
+      position: absolute;
+      bottom: -4px;
+      left: 0;
+      transition: all 0.3s ease;
+    }
+    &:hover {
+      &::before {
+        transform: scaleX(1);
+      }
+    }
+  }
+  ul {
+    margin: 20px 0;
+    padding-left: 24px;
+    padding: 10px 30px;
+    background: lighten($text-color, 75%);
+    border-radius: 4px;
+    list-style-type: none;
+    @include media(md, max) {
+      padding: 10px 20px;
+    }
+    li {
+      margin: 10px 0;
+    }
+  }
+  blockquote {
+    padding: 10px 30px;
+    border: 1px solid lighten($text-color, 60%);
+    border-radius: 4px;
+  }
+  code,
+  em {
+    @include font-bold;
+  }
+  table {
+    width: 100%;
+    margin: 30px 0;
+    border-collapse: collapse;
+    border: 1px solid $border-color;
+    background: $white-color;
+  }
+  th,
+  td {
+    padding: 8px 16px;
+    border-bottom: 1px solid $border-color;
+    border-right: 1px solid $border-color;
+  }
+  th {
+    background: lighten($text-color, 75%);
+    color: $text-color;
+    @include font-bold;
+    line-height: 1.6;
+  }
+  .video {
+    width: 100%;
+    padding-top: 56.25%;
+    position: relative;
+    iframe {
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      top: 0;
+      right: 0;
+    }
+  }
+}
+.l-top-button {
+  width: 100%;
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+}
+.base-button {
+  max-width: 240px;
+  width: 100%;
+}
+</style>

--- a/src/pages/tips/_slug.vue
+++ b/src/pages/tips/_slug.vue
@@ -53,8 +53,6 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
-
 import WorkImage from '~/components/Atoms/WorkImage'
 import BaseButton from '~/components/Atoms/BaseButton'
 import Pager from '~/components/Organisms/Pager'
@@ -68,8 +66,10 @@ export default {
   async asyncData({ payload, store, params, error }) {
     const currentPost =
       payload ||
-      (await store.state.posts.find((post) => post.fields.slug === params.slug))
-    const category = await store.state.categories.find(
+      (await store.getters.posts.find(
+        (post) => post.fields.slug === params.slug
+      ))
+    const category = await store.getters.categories.find(
       (cat) => cat.fields.slug === currentPost.fields.category.fields.slug
     )
     const relatedPosts = await store.getters.relatedPosts(category)
@@ -86,9 +86,6 @@ export default {
       return { currentPost, category, relatedPosts, prevPost, nextPost }
     }
     return error({ statusCode: 400 })
-  },
-  computed: {
-    ...mapGetters(['posts']),
   },
   methods: {
     toTop() {

--- a/src/pages/tips/index.vue
+++ b/src/pages/tips/index.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="container">
+    <div class="l-card">
+      <card-list>
+        <work-card
+          v-for="(post, i) in relatedPosts"
+          :key="i"
+          :to="post.fields.category.fields.slug + '/' + post.fields.slug"
+          :src="post.fields.headerImage.fields.file.url"
+          :alt="post.fields.title"
+          :category="post.fields.category.fields.name"
+          :title="post.fields.title"
+        />
+      </card-list>
+    </div>
+  </div>
+</template>
+
+<script>
+import WorkCard from '~/components/Modules/WorkCard'
+import CardList from '~/components/Organisms/CardList'
+
+export default {
+  components: {
+    WorkCard,
+    CardList,
+  },
+  async asyncData({ payload, store, error }) {
+    const currentPost =
+      payload ||
+      (await store.getters.posts.find(
+        (post) => post.fields.category.fields.slug === 'tips'
+      ))
+    const category = await store.getters.categories.find(
+      (cat) => cat.fields.slug === currentPost.fields.category.fields.slug
+    )
+    const relatedPosts = await store.getters.relatedPosts(category)
+    if (currentPost) {
+      return { currentPost, category, relatedPosts }
+    }
+    return error({ statusCode: 400 })
+  },
+}
+</script>
+
+<style lang="scss">
+.l-card {
+  padding: 0 24px;
+}
+</style>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,17 +2,29 @@ import client from '~/plugins/contentful'
 
 export const state = () => ({
   posts: [],
+  categories: [],
 })
 
 export const getters = {
   posts(state) {
     return state.posts
   },
+  categories(state) {
+    return state.categories
+  },
+  relatedPosts: (state) => (category) => {
+    return state.posts.filter(
+      (post) => post.fields.category.sys.id === category.sys.id
+    )
+  },
 }
 
 export const mutations = {
   setPosts(state, payload) {
     state.posts = payload
+  },
+  setCategories(state, payload) {
+    state.categories = payload
   },
 }
 
@@ -25,6 +37,18 @@ export const actions = {
       })
       .then((res) => {
         commit('setPosts', res.items)
+      })
+      // eslint-disable-next-line
+      .catch(console.error)
+  },
+  async getCategories({ commit }) {
+    await client
+      .getEntries({
+        content_type: 'category',
+        order: 'fields.sort',
+      })
+      .then((res) => {
+        commit('setCategories', res.items)
       })
       // eslint-disable-next-line
       .catch(console.error)


### PR DESCRIPTION
## 概要
新しく技術記事を投稿することになったので、
dailyuiとtipsをカテゴリー分けしてそれぞれのページに出力できるようにした。

## 変更内容
 - contentfulのcontent modelに新しくcategoryを作成、登録
 - contentfulのcontent modelに新しくportfolioPostを作成、登録
 - カテゴリーをstoreに登録
 - tipsの詳細ページを作成。dailyuiも取得値を改めて変更。
 - カテゴリーページのルートを追加
 - 各カテゴリーの一覧ページを作成
 - ナビゲーションにカテゴリー名を追加
 - aboutの内容を変更

## 参考サイト
https://blog.cloud-acct.com/posts/blog-creating-category
https://blog.cloud-acct.com/posts/blog-refarences-category
https://blog.cloud-acct.com/posts/blog-related-posts