### PR TITLE
リダイレクトで末尾の/がつくのでsubFoldersを追加

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -128,6 +128,7 @@ export default {
   // 動的ルーティング追加
   generate: {
     fallback: true,
+    subFolders: false,
     routes() {
       return Promise.all([
         client.getEntries({


### PR DESCRIPTION
## 概要
表題ママ

## 変更内容
 - nuxt.config.jsのgenerateに`subFolders: false`を追加した

## 参考
https://ja.nuxtjs.org/docs/2.x/configuration-glossary/configuration-generate/#subfolders
https://www.fu9da.com/post/nuxt-subfolders