### PR TITLE
無限スクロール追加

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -82,7 +82,14 @@ export default {
   css: [],
 
   // Plugins to run before rendering page (https://go.nuxtjs.dev/config-plugins)
-  plugins: ['~/plugins/adobe-fonts', '~/plugins/contentful'],
+  plugins: [
+    '~/plugins/adobe-fonts',
+    '~/plugins/contentful',
+    {
+      src: '~/plugins/infiniteloading',
+      ssr: false,
+    },
+  ],
 
   // Auto import components (https://go.nuxtjs.dev/config-components)
   components: true,

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "nuxt-webfontloader": "^1.1.0",
     "prettier": "^2.1.2",
     "sass-loader": "^10.1.0",
-    "sass-resources-loader": "^2.1.1"
+    "sass-resources-loader": "^2.1.1",
+    "vue-infinite-loading": "^2.4.5"
   }
 }

--- a/src/pages/dailyui/index.vue
+++ b/src/pages/dailyui/index.vue
@@ -3,7 +3,7 @@
     <div class="l-card">
       <card-list>
         <work-card
-          v-for="(post, i) in relatedPosts"
+          v-for="(post, i) in displayPosts"
           :key="i"
           :to="post.fields.category.fields.slug + '/' + post.fields.slug"
           :src="post.fields.headerImage.fields.file.url"
@@ -12,6 +12,14 @@
           :title="post.fields.title"
         />
       </card-list>
+      <infinite-loading
+        ref="infiniteLoading"
+        spinner="spiral"
+        @infinite="infiniteHandler"
+      >
+        <span slot="no-more"></span>
+        <span slot="no-results"></span>
+      </infinite-loading>
     </div>
   </div>
 </template>
@@ -22,6 +30,7 @@ import WorkCard from '~/components/Modules/WorkCard'
 import CardList from '~/components/Organisms/CardList'
 
 export default {
+  name: 'InfiniteScroll',
   components: {
     WorkCard,
     CardList,
@@ -41,8 +50,31 @@ export default {
     }
     return error({ statusCode: 400 })
   },
+  data() {
+    return {
+      displayPosts: [],
+      pageIndex: 0,
+      perPage: 12,
+    }
+  },
   computed: {
     ...mapGetters(['posts']),
+  },
+  methods: {
+    infiniteHandler($state) {
+      setTimeout(() => {
+        this.pageIndex++
+        this.displayPosts = this.relatedPosts.slice(
+          0,
+          (this.pageIndex + 1) * this.perPage
+        )
+        if (this.displayPosts.length !== this.relatedPosts.length) {
+          $state.loaded()
+        } else {
+          $state.complete()
+        }
+      }, 1000)
+    },
   },
 }
 </script>

--- a/src/pages/dailyui/index.vue
+++ b/src/pages/dailyui/index.vue
@@ -1,17 +1,19 @@
 <template>
   <div class="container">
     <div class="l-card">
-      <card-list>
-        <work-card
-          v-for="(post, i) in displayPosts"
-          :key="i"
-          :to="post.fields.category.fields.slug + '/' + post.fields.slug"
-          :src="post.fields.headerImage.fields.file.url"
-          :alt="post.fields.title"
-          :category="post.fields.category.fields.name"
-          :title="post.fields.title"
-        />
-      </card-list>
+      <transition appear name="fadein">
+        <card-list>
+          <work-card
+            v-for="(post, i) in displayPosts"
+            :key="i"
+            :to="post.fields.category.fields.slug + '/' + post.fields.slug"
+            :src="post.fields.headerImage.fields.file.url"
+            :alt="post.fields.title"
+            :category="post.fields.category.fields.name"
+            :title="post.fields.title"
+          />
+        </card-list>
+      </transition>
       <infinite-loading
         ref="infiniteLoading"
         spinner="spiral"

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -5,7 +5,7 @@
       <transition appear name="fadein">
         <card-list>
           <work-card
-            v-for="(post, i) in posts"
+            v-for="(post, i) in displayPosts"
             :key="i"
             :to="post.fields.category.fields.slug + '/' + post.fields.slug"
             :src="post.fields.headerImage.fields.file.url"
@@ -15,6 +15,14 @@
           />
         </card-list>
       </transition>
+      <infinite-loading
+        ref="infiniteLoading"
+        spinner="spiral"
+        @infinite="infiniteHandler"
+      >
+        <span slot="no-more"></span>
+        <span slot="no-results"></span>
+      </infinite-loading>
     </div>
   </div>
 </template>
@@ -26,13 +34,39 @@ import WorkCard from '~/components/Modules/WorkCard'
 import CardList from '~/components/Organisms/CardList'
 
 export default {
+  name: 'InfiniteScroll',
   components: {
     Catch,
     WorkCard,
     CardList,
   },
+  data() {
+    return {
+      displayPosts: [],
+      pageIndex: 0,
+      perPage: 12,
+    }
+  },
   computed: {
     ...mapGetters(['posts', 'categories']),
+  },
+  methods: {
+    infiniteHandler($state) {
+      console.info(this.displayPosts)
+      console.info(this.posts)
+      setTimeout(() => {
+        this.pageIndex++
+        this.displayPosts = this.posts.slice(
+          0,
+          (this.pageIndex + 1) * this.perPage
+        )
+        if (this.displayPosts.length !== this.posts.length) {
+          $state.loaded()
+        } else {
+          $state.complete()
+        }
+      }, 1000)
+    },
   },
 }
 </script>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -52,8 +52,6 @@ export default {
   },
   methods: {
     infiniteHandler($state) {
-      console.info(this.displayPosts)
-      console.info(this.posts)
       setTimeout(() => {
         this.pageIndex++
         this.displayPosts = this.posts.slice(

--- a/src/pages/tips/index.vue
+++ b/src/pages/tips/index.vue
@@ -1,17 +1,19 @@
 <template>
   <div class="container">
     <div class="l-card">
-      <card-list>
-        <work-card
-          v-for="(post, i) in displayPosts"
-          :key="i"
-          :to="post.fields.category.fields.slug + '/' + post.fields.slug"
-          :src="post.fields.headerImage.fields.file.url"
-          :alt="post.fields.title"
-          :category="post.fields.category.fields.name"
-          :title="post.fields.title"
-        />
-      </card-list>
+      <transition appear name="fadein">
+        <card-list>
+          <work-card
+            v-for="(post, i) in displayPosts"
+            :key="i"
+            :to="post.fields.category.fields.slug + '/' + post.fields.slug"
+            :src="post.fields.headerImage.fields.file.url"
+            :alt="post.fields.title"
+            :category="post.fields.category.fields.name"
+            :title="post.fields.title"
+          />
+        </card-list>
+      </transition>
       <infinite-loading
         ref="infiniteLoading"
         spinner="spiral"

--- a/src/pages/tips/index.vue
+++ b/src/pages/tips/index.vue
@@ -3,7 +3,7 @@
     <div class="l-card">
       <card-list>
         <work-card
-          v-for="(post, i) in relatedPosts"
+          v-for="(post, i) in displayPosts"
           :key="i"
           :to="post.fields.category.fields.slug + '/' + post.fields.slug"
           :src="post.fields.headerImage.fields.file.url"
@@ -12,6 +12,14 @@
           :title="post.fields.title"
         />
       </card-list>
+      <infinite-loading
+        ref="infiniteLoading"
+        spinner="spiral"
+        @infinite="infiniteHandler"
+      >
+        <span slot="no-more"></span>
+        <span slot="no-results"></span>
+      </infinite-loading>
     </div>
   </div>
 </template>
@@ -21,6 +29,7 @@ import WorkCard from '~/components/Modules/WorkCard'
 import CardList from '~/components/Organisms/CardList'
 
 export default {
+  name: 'InfiniteScroll',
   components: {
     WorkCard,
     CardList,
@@ -39,6 +48,29 @@ export default {
       return { currentPost, category, relatedPosts }
     }
     return error({ statusCode: 400 })
+  },
+  data() {
+    return {
+      displayPosts: [],
+      pageIndex: 0,
+      perPage: 12,
+    }
+  },
+  methods: {
+    infiniteHandler($state) {
+      setTimeout(() => {
+        this.pageIndex++
+        this.displayPosts = this.relatedPosts.slice(
+          0,
+          (this.pageIndex + 1) * this.perPage
+        )
+        if (this.displayPosts.length !== this.relatedPosts.length) {
+          $state.loaded()
+        } else {
+          $state.complete()
+        }
+      }, 1000)
+    },
   },
 }
 </script>

--- a/src/plugins/infiniteloading.js
+++ b/src/plugins/infiniteloading.js
@@ -1,0 +1,4 @@
+import Vue from 'vue'
+import InfiniteLoading from 'vue-infinite-loading'
+
+Vue.component('infinite-loading', InfiniteLoading)

--- a/yarn.lock
+++ b/yarn.lock
@@ -13396,6 +13396,11 @@ vue-inbrowser-compiler-utils@^4.33.6:
   dependencies:
     camelcase "^5.3.1"
 
+vue-infinite-loading@^2.4.5:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/vue-infinite-loading/-/vue-infinite-loading-2.4.5.tgz#cc20fd40af7f20188006443c99b60470cf1de1b3"
+  integrity sha512-xhq95Mxun060bRnsOoLE2Be6BR7jYwuC89kDe18+GmCLVrRA/dU0jrGb12Xu6NjmKs+iTW0AA6saSEmEW4cR7g==
+
 vue-loader@^15.9.5:
   version "15.9.5"
   resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-15.9.5.tgz#7a960dc420a3439deaacdda038fdcdbf7c432706"


### PR DESCRIPTION
## 概要
トップ、DailyUIトップ、Tipsトップに無限スクロールを追加。

## 変更内容
- vue-infinite-loadingインストール
- 無限スクロールする記述を追加
- DailyUIトップ、Tipsトップのカード一覧にtransitionを追加

## 参考サイト
https://qiita.com/yakiniku0220/items/1b2e960a09a9f085820e
